### PR TITLE
Clarifier la home et adoucir l’identité

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# comptable
+# Comptable Pro
+
+Site vitrine statique qui compare les principaux cabinets comptables en ligne. La page d'accueil propose un hero introductif léger et un tableau comparatif directement accessible. Chaque cabinet dispose d'une fiche individuelle avec une colonne B dédiée aux appels à l'action.
+
+## Structure
+- `index.html` : page d'accueil avec comparatif, méthodologie, FAQ et contact.
+- `cabinets/` : fiches détaillées (Indy, Dougs, Keobiz, L-expert-comptable.com, Livli, Clémentine).
+- `styles.css` : feuille de style globale responsive inspirée des codes graphiques d'envoi-de-fleurs.fr.
+- `assets/` : éléments graphiques.
+
+## Prévisualisation locale
+```bash
+# depuis le dossier du projet
+python -m http.server 8000
+```
+Puis ouvrez `http://localhost:8000/index.html` dans votre navigateur.
+
+Le site est responsive et pensé pour une expérience mobile et desktop.

--- a/cabinets/clementine.html
+++ b/cabinets/clementine.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clémentine : cabinet comptable premium pour scale-up | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Découvrez l'offre Clémentine : pilotage financier, reporting et accompagnement stratégique pour TPE/PME en croissance."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="../index.html#comparatif">Comparatif</a></li>
+              <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li><a href="../index.html#faq">FAQ</a></li>
+              <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero" id="contenu">
+          <div class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Clémentine</span>
+            </div>
+            <h1>Clémentine&nbsp;: du pilotage financier au conseil stratégique</h1>
+            <p>
+              Cabinet premium dédié aux entreprises en croissance, Clémentine combine expertise comptable, contrôle de gestion et
+              stratégie financière pour accélérer vos décisions.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,8/5</span>
+              <span><strong>Clients types</strong> Scale-up, PME multi-sites</span>
+              <span><strong>Onboarding</strong> 20 jours ouvrés</span>
+            </div>
+          </div>
+          <ul class="hero-highlights" role="list">
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M5 12l4 4 10-10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Contrôleur de gestion dédié et reportings sur mesure
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 6v12m6-6H6"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Accompagnement sur la structuration de la finance d'entreprise (BI, KPI, levée de fonds)
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Squad pluridisciplinaire (comptables, DAF à temps partagé, juristes)
+            </li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div class="page">
+        <div class="layout-grid">
+          <div class="main-column">
+            <section class="section" aria-labelledby="clementine-forces">
+              <h2 id="clementine-forces">Forces clés de Clémentine</h2>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Pilotage financier sur mesure</h3>
+                  <p>
+                    Élaboration de tableaux de bord personnalisés, suivi de KPIs et scénarios budgétaires adaptés à vos enjeux de
+                    croissance.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Accompagnement stratégique</h3>
+                  <p>
+                    Conseil en levée de fonds, structuration de la fonction finance et accompagnement sur les opérations de M&A.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Gestion multi-sites</h3>
+                  <p>
+                    Processus éprouvés pour consolider les données financières de plusieurs établissements et garantir une vision
+                    groupe.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section class="section" aria-labelledby="clementine-tarifs">
+              <h2 id="clementine-tarifs">Tarifs Clémentine</h2>
+              <div class="plan-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Formule</th>
+                      <th scope="col">Contenu</th>
+                      <th scope="col">Prix</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Pack Croissance</th>
+                      <td>Tenue comptable, bilans, réunions de pilotage trimestrielles</td>
+                      <td>Sur devis (à partir de 249&nbsp;€&nbsp;HT/mois)</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Pack Scale-up</th>
+                      <td>DAF à temps partagé, reporting investisseurs, scénarios budgétaires</td>
+                      <td>Sur devis</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Pack Transaction</th>
+                      <td>Due diligence, valorisation, accompagnement levée de fonds</td>
+                      <td>Honoraires selon mission</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="section" aria-labelledby="clementine-vigilance">
+              <h2 id="clementine-vigilance">Points de vigilance</h2>
+              <p class="lead">
+                Clémentine s'adresse aux structures ambitieuses. Assurez-vous d'avoir une équipe interne disponible pour tirer
+                parti des ateliers stratégiques proposés.
+              </p>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Disponibilité des équipes</h3>
+                  <p>
+                    Les sessions de pilotage nécessitent l'implication de la direction et des managers pour être efficaces.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Budget</h3>
+                  <p>
+                    Positionnement premium&nbsp;: prévoyez un budget supérieur aux cabinets automatisés pour bénéficier du
+                    conseil stratégique.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <aside class="sidebar" aria-label="Colonne B">
+            <div class="sidebar-card">
+              <h3>Planifier une session Clémentine</h3>
+              <p>Organisez un diagnostic financier avec un DAF à temps partagé Clémentine.</p>
+              <a class="button button-primary" href="mailto:contact@example.com?subject=Session%20d%C3%A9couverte%20Cl%C3%A9mentine">Demander un diagnostic</a>
+              <ul>
+                <li><span>Délai</span>72&nbsp;h</li>
+                <li><span>Durée</span>1&nbsp;h</li>
+                <li><span>Format</span>Visio stratégique</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Profil idéal</h3>
+              <ul>
+                <li><span>CA</span>&gt; 2&nbsp;M€</li>
+                <li><span>Équipe</span>Finance interne</li>
+                <li><span>Objectif</span>Structurer la fonction finance</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Documents à préparer</h3>
+              <p>Business plan, reporting actuel et projections pour accélérer la prise en main.</p>
+              <a class="cta-link" href="#">Télécharger la trame</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/cabinets/dougs.html
+++ b/cabinets/dougs.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dougs : avis et analyse du cabinet comptable en ligne | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Analyse complète de Dougs : fonctionnalités, accompagnement, tarifs et points d'attention pour choisir ce cabinet comptable en ligne."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="../index.html#comparatif">Comparatif</a></li>
+              <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li><a href="../index.html#faq">FAQ</a></li>
+              <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero" id="contenu">
+          <div class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Dougs</span>
+            </div>
+            <h1>Dougs&nbsp;: la pédagogie comptable 100&nbsp;% en ligne</h1>
+            <p>
+              Dougs combine une application mobile complète, des webinars réguliers et un accompagnement humain structuré pour
+              aider les dirigeants à prendre des décisions éclairées.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,6/5</span>
+              <span><strong>Clients types</strong> SASU, SARL, professions libérales</span>
+              <span><strong>Onboarding</strong> 12 jours ouvrés</span>
+            </div>
+          </div>
+          <ul class="hero-highlights" role="list">
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M5 12l4 4 10-10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Tableaux de bord de trésorerie et alertes personnalisées
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 6v12m6-6H6"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Parcours d'onboarding en vidéos pour comprendre chaque étape
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Option sociale et juridique intégrée pour gérer vos obligations
+            </li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div class="page">
+        <div class="layout-grid">
+          <div class="main-column">
+            <section class="section" aria-labelledby="dougs-forces">
+              <h2 id="dougs-forces">Forces clés de Dougs</h2>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Vision financière en temps réel</h3>
+                  <p>
+                    L'application propose des graphiques de trésorerie, un prévisionnel et des alertes personnalisées sur vos
+                    obligations et seuils de TVA.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Contenus pédagogiques</h3>
+                  <p>
+                    Webinars, masterclass et articles pour comprendre les enjeux comptables et fiscaux selon votre statut
+                    juridique.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Équipe pluridisciplinaire</h3>
+                  <p>
+                    Comptables, juristes et gestionnaires de paie sous le même toit pour un accompagnement coordonné.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section class="section" aria-labelledby="dougs-tarifs">
+              <h2 id="dougs-tarifs">Tarifs Dougs</h2>
+              <div class="plan-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Formule</th>
+                      <th scope="col">Contenu</th>
+                      <th scope="col">Prix</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Essentiel</th>
+                      <td>Tenue comptable, bilans, application et support illimité</td>
+                      <td>79&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Premium</th>
+                      <td>Rendez-vous conseil trimestriels, business plan, simulations fiscales</td>
+                      <td>119&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Option sociale</th>
+                      <td>Gestion de la paie et déclarations sociales</td>
+                      <td>29&nbsp;€&nbsp;HT/mois / salarié</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="section" aria-labelledby="dougs-vigilance">
+              <h2 id="dougs-vigilance">Points de vigilance</h2>
+              <p class="lead">
+                Le modèle 100&nbsp;% en ligne de Dougs demande une bonne autonomie digitale. Les rendez-vous doivent être
+                planifiés à l'avance, surtout en période fiscale.
+              </p>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Disponibilité des conseillers</h3>
+                  <p>
+                    Anticipez vos demandes&nbsp;: les plages de rendez-vous peuvent être saturées durant les clôtures annuelles.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Intégrations spécifiques</h3>
+                  <p>
+                    Certaines intégrations métiers (CRM, outils SaaS) nécessitent des développements API complémentaires.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <aside class="sidebar" aria-label="Colonne B">
+            <div class="sidebar-card">
+              <h3>Réserver une démo Dougs</h3>
+              <p>Profitez d'une présentation personnalisée de l'application et de ses modules temps réel.</p>
+              <a class="button button-primary" href="mailto:contact@example.com?subject=Demande%20de%20d%C3%A9mo%20Dougs">Programmer une démo</a>
+              <ul>
+                <li><span>Délai</span>48&nbsp;h</li>
+                <li><span>Durée</span>45&nbsp;min</li>
+                <li><span>Support</span>Visio + replay</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Profil idéal</h3>
+              <ul>
+                <li><span>Statut</span>SASU / SARL</li>
+                <li><span>Équipe</span>1 à 20 salariés</li>
+                <li><span>Besoin</span>Reporting dynamique</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Aller plus loin</h3>
+              <p>Découvrir les cas clients Dougs pour valider l'adéquation avec votre secteur.</p>
+              <a class="cta-link" href="https://www.dougs.fr/blog/" target="_blank" rel="noopener">Accéder au blog</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/cabinets/indy.html
+++ b/cabinets/indy.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Indy : notre avis sur le cabinet comptable en ligne | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Découvrez l'analyse complète d'Indy : automatisation comptable, accompagnement, tarifs et points de vigilance pour indépendants."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="../index.html#comparatif">Comparatif</a></li>
+              <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li><a href="../index.html#faq">FAQ</a></li>
+              <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero" id="contenu">
+          <div class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Indy</span>
+            </div>
+            <h1>Indy&nbsp;: l'automatisation comptable pour les indépendants</h1>
+            <p>
+              Plateforme conçue pour les professions libérales, freelances et micro-entrepreneurs qui souhaitent automatiser
+              la tenue comptable, sécuriser leurs déclarations et gagner du temps sur l'administratif.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,7/5</span>
+              <span><strong>Clients types</strong> BNC, BIC, SCM</span>
+              <span><strong>Onboarding</strong> 7 jours ouvrés</span>
+            </div>
+          </div>
+          <ul class="hero-highlights" role="list">
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 6v12m6-6H6"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Déclarations fiscales pré-remplies (2035, TVA) et rappels automatisés
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M5 12l4 4 10-10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Application mobile pour scanner les justificatifs en temps réel
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Bibliothèque de guides et webinars pédagogiques accessibles 24/7
+            </li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div class="page">
+        <div class="layout-grid">
+          <div class="main-column">
+            <section class="section" aria-labelledby="indy-forces">
+              <h2 id="indy-forces">Forces clés d'Indy</h2>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Automatisation poussée</h3>
+                  <p>
+                    Synchronisation bancaire instantanée, catégorisation automatique des opérations et génération de la liasse
+                    fiscale en un clic.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Accompagnement fiscal</h3>
+                  <p>
+                    Conseillers spécialisés BNC disponibles par chat et téléphone pour sécuriser les déclarations complexes et
+                    anticiper les optimisations.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Expérience utilisateur</h3>
+                  <p>
+                    Interface claire, checklist de tâches et notifications intelligentes pour suivre les échéances sans stress.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section class="section" aria-labelledby="indy-tarifs">
+              <h2 id="indy-tarifs">Tarifs et forfaits Indy</h2>
+              <div class="plan-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Formule</th>
+                      <th scope="col">Contenu</th>
+                      <th scope="col">Prix</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Indy Essentiel</th>
+                      <td>Tenue comptable automatisée, TVA, liasses et support chat</td>
+                      <td>49&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Indy Premium</th>
+                      <td>Accompagnement fiscal renforcé, rendez-vous illimités, formation</td>
+                      <td>79&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Option paie</th>
+                      <td>Bulletins de salaire externalisés pour structures avec salariés</td>
+                      <td>25&nbsp;€&nbsp;HT/mois / salarié</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="section" aria-labelledby="indy-vigilance">
+              <h2 id="indy-vigilance">Points de vigilance</h2>
+              <p class="lead">
+                Indy excelle pour les entrepreneurs individuels. Pour les sociétés plus structurées, certaines fonctionnalités
+                peuvent nécessiter l'intervention d'un cabinet partenaire.
+              </p>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Sociétés à forte volumétrie</h3>
+                  <p>
+                    Les workflows multi-utilisateurs et les exports avancés sont limités. Privilégiez un cabinet hybride si
+                    vous traitez plusieurs milliers d'écritures par mois.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Gestion de la paie</h3>
+                  <p>
+                    La production des bulletins est externalisée&nbsp;: anticipez le délai de mise en place et vérifiez les
+                    coûts supplémentaires en cas de croissance de l'effectif.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <aside class="sidebar" aria-label="Colonne B">
+            <div class="sidebar-card">
+              <h3>Être rappelé par Indy</h3>
+              <p>Nous organisons un rendez-vous de démonstration avec un conseiller spécialisé.</p>
+              <a class="button button-primary" href="mailto:contact@example.com?subject=Mise%20en%20relation%20Indy">Je veux une démo</a>
+              <ul>
+                <li><span>Délai</span>24&nbsp;h</li>
+                <li><span>Durée</span>30&nbsp;min</li>
+                <li><span>Format</span>Visio personnalisée</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Profil idéal</h3>
+              <ul>
+                <li><span>Statut</span>BNC / Freelance</li>
+                <li><span>Logiciel actuel</span>Excel / Tableur</li>
+                <li><span>Objectif</span>Automatiser 90&nbsp;% des tâches</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Prochaines étapes</h3>
+              <p>Préparez vos accès bancaires et vos déclarations précédentes pour accélérer la migration.</p>
+              <a class="cta-link" href="../index.html#contact">Parler à un expert Comptable Pro</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/cabinets/keobiz.html
+++ b/cabinets/keobiz.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Keobiz : analyse de l'offre comptable en ligne | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Notre avis sur Keobiz : accompagnement juridique, tarification et points de vigilance pour les créateurs et sociétés en croissance."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="../index.html#comparatif">Comparatif</a></li>
+              <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li><a href="../index.html#faq">FAQ</a></li>
+              <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero" id="contenu">
+          <div class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Keobiz</span>
+            </div>
+            <h1>Keobiz&nbsp;: comptabilité et juridique pour les entrepreneurs ambitieux</h1>
+            <p>
+              Keobiz propose un accompagnement 360° mêlant création d'entreprise, gestion comptable et suivi juridique, idéal
+              pour les dirigeants qui veulent un partenaire unique.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,5/5</span>
+              <span><strong>Clients types</strong> Créateurs, TPE, PME</span>
+              <span><strong>Onboarding</strong> 15 jours ouvrés</span>
+            </div>
+          </div>
+          <ul class="hero-highlights" role="list">
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M5 12l4 4 10-10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Formalités de création d'entreprise offertes sous conditions
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 6v12m6-6H6"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Plateforme collaborative pour déposer et suivre les documents en temps réel
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Pôle juridique internalisé pour les assemblées et modifications statutaires
+            </li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div class="page">
+        <div class="layout-grid">
+          <div class="main-column">
+            <section class="section" aria-labelledby="keobiz-forces">
+              <h2 id="keobiz-forces">Forces clés de Keobiz</h2>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Accompagnement création</h3>
+                  <p>
+                    Conseils sur le statut juridique, rédaction des statuts et immatriculation accélérée grâce au guichet unique
+                    Keobiz.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Équipe pluridisciplinaire</h3>
+                  <p>
+                    Comptables, fiscalistes et juristes coordonnés pour assurer la conformité et la réactivité sur toutes vos
+                    obligations.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Offre modulable</h3>
+                  <p>
+                    Possibilité d'ajouter des missions (social, juridique, conseil) à la carte sans changer de prestataire.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section class="section" aria-labelledby="keobiz-tarifs">
+              <h2 id="keobiz-tarifs">Tarifs Keobiz</h2>
+              <div class="plan-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Formule</th>
+                      <th scope="col">Contenu</th>
+                      <th scope="col">Prix</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Starter</th>
+                      <td>Tenue comptable, bilan, déclarations fiscales, assistance illimitée</td>
+                      <td>49&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Performance</th>
+                      <td>Conseil fiscal trimestriel, optimisation rémunération dirigeant</td>
+                      <td>89&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Pack juridique</th>
+                      <td>Assemblées générales, modifications statutaires, baux commerciaux</td>
+                      <td>Sur devis</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="section" aria-labelledby="keobiz-vigilance">
+              <h2 id="keobiz-vigilance">Points de vigilance</h2>
+              <p class="lead">
+                L'offre Keobiz est dense&nbsp;: vérifiez que les options choisies correspondent à vos besoins pour éviter les
+                surcoûts.
+              </p>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Tarifs modulaires</h3>
+                  <p>
+                    Certaines prestations sont facturées à l'acte. Demandez un devis détaillé pour évaluer le coût total de
+                    possession.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Suivi projet</h3>
+                  <p>
+                    Prévoyez un chef de projet côté client pour coordonner les actions juridiques et comptables simultanées.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <aside class="sidebar" aria-label="Colonne B">
+            <div class="sidebar-card">
+              <h3>Prendre contact avec Keobiz</h3>
+              <p>Nous organisons une session de découverte de l'offre comptable et juridique.</p>
+              <a class="button button-primary" href="mailto:contact@example.com?subject=Mise%20en%20relation%20Keobiz">Je souhaite être rappelé</a>
+              <ul>
+                <li><span>Délai</span>48&nbsp;h</li>
+                <li><span>Durée</span>45&nbsp;min</li>
+                <li><span>Support</span>Visio ou présentiel</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Profil idéal</h3>
+              <ul>
+                <li><span>Statut</span>SAS / SARL</li>
+                <li><span>Phase</span>Création ou croissance</li>
+                <li><span>Besoin</span>Pack 360°</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Document ressource</h3>
+              <p>Téléchargez notre guide pour réussir votre création d'entreprise avec Keobiz.</p>
+              <a class="cta-link" href="#">Télécharger le guide</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/cabinets/lexpert.html
+++ b/cabinets/lexpert.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>L-expert-comptable.com : fiche cabinet | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Avis et analyse de L-expert-comptable.com : forces, tarifs et recommandations pour choisir ce cabinet en ligne."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="../index.html#comparatif">Comparatif</a></li>
+              <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li><a href="../index.html#faq">FAQ</a></li>
+              <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero" id="contenu">
+          <div class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>L-expert-comptable.com</span>
+            </div>
+            <h1>L-expert-comptable.com&nbsp;: un accompagnement digital et pédagogique</h1>
+            <p>
+              Cabinet pionnier de la comptabilité en ligne, L-expert-comptable.com combine plateforme intuitive, contenus
+              pédagogiques et réseau d'experts pour accompagner les dirigeants de TPE/PME.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,5/5</span>
+              <span><strong>Clients types</strong> TPE, PME, start-up</span>
+              <span><strong>Onboarding</strong> 14 jours ouvrés</span>
+            </div>
+          </div>
+          <ul class="hero-highlights" role="list">
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M5 12l4 4 10-10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Accès à un centre de ressources complet (guides, webinars, podcasts)
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 6v12m6-6H6"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Plateforme collaborative pour partager les pièces et suivre les tâches
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Communauté de dirigeants et événements réguliers pour partager les bonnes pratiques
+            </li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div class="page">
+        <div class="layout-grid">
+          <div class="main-column">
+            <section class="section" aria-labelledby="lexpert-forces">
+              <h2 id="lexpert-forces">Forces clés de L-expert-comptable.com</h2>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Plateforme collaborative</h3>
+                  <p>
+                    Gestion documentaire fluide, rappels automatiques et workflows de validation adaptés aux équipes.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Ressources pédagogiques</h3>
+                  <p>
+                    Webinars et guides sectoriels pour aider les dirigeants à comprendre les impacts fiscaux et sociaux.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Accompagnement juridique</h3>
+                  <p>
+                    Assistance aux opérations sur capital, pactes d'associés et missions juridiques récurrentes via le réseau
+                    Lexpert.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section class="section" aria-labelledby="lexpert-tarifs">
+              <h2 id="lexpert-tarifs">Tarifs L-expert-comptable.com</h2>
+              <div class="plan-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Formule</th>
+                      <th scope="col">Contenu</th>
+                      <th scope="col">Prix</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Essentielle</th>
+                      <td>Tenue comptable, TVA, bilans et accompagnement dédié</td>
+                      <td>À partir de 69&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Croissance</th>
+                      <td>Reporting financier, consolidation et conseil stratégique</td>
+                      <td>Sur devis</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Pack juridique</th>
+                      <td>Assemblées, modifications statutaires, secrétariat juridique</td>
+                      <td>À partir de 39&nbsp;€&nbsp;HT/acte</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="section" aria-labelledby="lexpert-vigilance">
+              <h2 id="lexpert-vigilance">Points de vigilance</h2>
+              <p class="lead">
+                L'offre est riche en fonctionnalités. Accompagnez vos équipes pour tirer parti de la plateforme et planifiez les
+                sessions de formation proposées.
+              </p>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Prise en main de la plateforme</h3>
+                  <p>
+                    Prévoir un temps de formation initial pour les équipes finance afin d'utiliser tous les modules disponibles.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Facturation des actes juridiques</h3>
+                  <p>
+                    Les actes juridiques sont facturés à la carte. Demandez une projection annuelle pour maîtriser votre budget.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <aside class="sidebar" aria-label="Colonne B">
+            <div class="sidebar-card">
+              <h3>Contact dédié L-expert-comptable.com</h3>
+              <p>Planifiez une réunion avec un expert sectoriel pour passer en revue vos enjeux.</p>
+              <a class="button button-primary" href="mailto:contact@example.com?subject=Mise%20en%20relation%20L-expert-comptable.com">Planifier un échange</a>
+              <ul>
+                <li><span>Délai</span>72&nbsp;h</li>
+                <li><span>Durée</span>45&nbsp;min</li>
+                <li><span>Format</span>Visio ou physique</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Profil idéal</h3>
+              <ul>
+                <li><span>Statut</span>SAS / SA / Start-up</li>
+                <li><span>Équipe</span>Finance structurée</li>
+                <li><span>Besoin</span>Ressources pédagogiques</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Ressources utiles</h3>
+              <p>Explorez les guides sectoriels (SaaS, restauration, agences) pour préparer votre rendez-vous.</p>
+              <a class="cta-link" href="https://www.l-expert-comptable.com/guides" target="_blank" rel="noopener">Voir les guides</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/cabinets/livli.html
+++ b/cabinets/livli.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Livli : expertise comptable pour e-commerçants | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Nos recommandations sur Livli : intégrations e-commerce, automatisation et accompagnement des marchands en ligne."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="../index.html#comparatif">Comparatif</a></li>
+              <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li><a href="../index.html#faq">FAQ</a></li>
+              <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero" id="contenu">
+          <div class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Livli</span>
+            </div>
+            <h1>Livli&nbsp;: l'expertise comptable pensée pour l'e-commerce</h1>
+            <p>
+              Livli connecte vos marketplaces et CMS à sa plateforme pour automatiser la récupération des ventes et optimiser
+              votre rentabilité produit par produit.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,6/5</span>
+              <span><strong>Clients types</strong> DNVB, e-commerçants, retail</span>
+              <span><strong>Onboarding</strong> 10 jours ouvrés</span>
+            </div>
+          </div>
+          <ul class="hero-highlights" role="list">
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M5 12l4 4 10-10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Connecteurs natifs Shopify, Amazon, Prestashop et WooCommerce
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 6v12m6-6H6"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Analyses de marge produit et reporting logistique pour piloter vos stocks
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Équipe dédiée e-commerce avec veille TVA intracommunautaire
+            </li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div class="page">
+        <div class="layout-grid">
+          <div class="main-column">
+            <section class="section" aria-labelledby="livli-forces">
+              <h2 id="livli-forces">Forces clés de Livli</h2>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Connecteurs e-commerce</h3>
+                  <p>
+                    Synchronisation automatique des ventes, remboursements et frais plateformes pour limiter les ressaisies.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Reporting granularité produit</h3>
+                  <p>
+                    Tableaux de bord dédiés aux marges, coûts logistiques et campagnes marketing pour ajuster vos prix en temps
+                    réel.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Veille TVA internationale</h3>
+                  <p>
+                    Surveillance des seuils OSS/IOSS, gestion des immatriculations et conseil sur la facturation multidevise.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section class="section" aria-labelledby="livli-tarifs">
+              <h2 id="livli-tarifs">Tarifs Livli</h2>
+              <div class="plan-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Formule</th>
+                      <th scope="col">Contenu</th>
+                      <th scope="col">Prix</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Comfort</th>
+                      <td>Tenue comptable, déclarations TVA, connecteurs marketplace</td>
+                      <td>79&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Performance</th>
+                      <td>Reporting avancé, conseil fiscal international, pilotage stocks</td>
+                      <td>119&nbsp;€&nbsp;HT/mois</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Option logistique</th>
+                      <td>Analyse coûts transporteurs, optimisation TVA entrepôts UE</td>
+                      <td>Sur devis</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="section" aria-labelledby="livli-vigilance">
+              <h2 id="livli-vigilance">Points de vigilance</h2>
+              <p class="lead">
+                Livli est particulièrement adapté aux structures digitales. Pour des activités physiques multi-sites, vérifiez la
+                capacité d'accompagnement local.
+              </p>
+              <ul class="highlight-list">
+                <li class="highlight-item">
+                  <h3>Paramétrage initial</h3>
+                  <p>
+                    Prévoyez un atelier technique pour connecter vos plateformes et aligner vos plans comptables.
+                  </p>
+                </li>
+                <li class="highlight-item">
+                  <h3>Gestion retail physique</h3>
+                  <p>
+                    Les processus sont optimisés pour les ventes en ligne. Pour les points de vente physiques, validez les
+                    options d'inventaire et de caisse.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <aside class="sidebar" aria-label="Colonne B">
+            <div class="sidebar-card">
+              <h3>Obtenir une démo Livli</h3>
+              <p>Nous organisons une session dédiée à vos flux marketplace et logistique.</p>
+              <a class="button button-primary" href="mailto:contact@example.com?subject=Demande%20de%20d%C3%A9mo%20Livli">Planifier une démo</a>
+              <ul>
+                <li><span>Délai</span>72&nbsp;h</li>
+                <li><span>Durée</span>45&nbsp;min</li>
+                <li><span>Format</span>Visio interactive</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Profil idéal</h3>
+              <ul>
+                <li><span>CA</span>&lt; 8&nbsp;M€</li>
+                <li><span>Canaux</span>Marketplaces &amp; site propre</li>
+                <li><span>Objectif</span>Suivi marge produit</li>
+              </ul>
+            </div>
+            <div class="sidebar-card">
+              <h3>Checklist e-commerce</h3>
+              <p>Préparez vos accès plateformes et flux logistiques pour un onboarding sans friction.</p>
+              <a class="cta-link" href="#">Télécharger la checklist</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,40 +4,37 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Comparatif des cabinets comptables en ligne | Comptable Pro</title>
+    <title>Comptable Pro | Comparatif des cabinets comptables en ligne</title>
     <meta
       name="description"
-      content="Découvrez un comparatif détaillé des cabinets comptables en ligne pour entrepreneurs : tarifs, services et points forts pour indy.fr, Dougs, Livli et plus."
+      content="Trouvez le cabinet comptable en ligne idéal grâce à notre comparatif détaillé, nos analyses et fiches dédiées aux principaux acteurs du marché."
     />
     <meta name="robots" content="index, follow" />
-    <meta name="theme-color" content="#0a4a7c" />
-
+    <meta name="theme-color" content="#ff7aa2" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Comparatif des cabinets comptables en ligne" />
+    <meta property="og:title" content="Comptable Pro | Comparatif des cabinets comptables en ligne" />
     <meta
       property="og:description"
-      content="Choisissez le cabinet comptable en ligne adapté à votre structure grâce à notre analyse professionnelle."
+      content="Analyse indépendante, tableau comparatif et fiches cabinet pour choisir votre expert-comptable en ligne."
     />
     <meta property="og:url" content="https://example.com/" />
     <meta property="og:locale" content="fr_FR" />
     <meta property="og:image" content="https://example.com/assets/images/hero-pattern.svg" />
-    <meta name="twitter:card" content="summary_large_image" />
-
+    <link rel="canonical" href="https://example.com/" />
     <link rel="preload" href="styles.css" as="style" />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="canonical" href="https://example.com/" />
   </head>
   <body>
-    <a href="#content" class="skip-link">Aller au contenu principal</a>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
     <header>
-      <div class="header-inner" role="banner">
-        <nav aria-label="Navigation principale">
-          <a class="brand" href="#">
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="index.html">
             <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255,255,255,0.18)" />
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
               <path
                 d="M16 32l6-14 4 6 6-10"
-                stroke="#ffffff"
+                stroke="#ff7aa2"
                 stroke-width="3"
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -45,306 +42,225 @@
             </svg>
             Comptable Pro
           </a>
-          <ul>
-            <li><a href="#comparatif">Comparatif</a></li>
-            <li><a href="#faq">FAQ</a></li>
-            <li><a href="#contact">Contact</a></li>
-          </ul>
-        </nav>
-        <div class="hero" id="content">
-          <div class="hero-content">
-            <h1>Choisissez le cabinet comptable en ligne qui accélère votre croissance</h1>
-            <p>
-              Nous analysons les acteurs clés du marché pour vous aider à sélectionner la solution qui répond à vos exigences
-              de réactivité, d’accompagnement et de conformité.
-            </p>
-            <div class="hero-cta">
-              <a class="button button-primary" href="#comparatif">Explorer le comparatif</a>
-              <a class="button button-secondary" href="#contact">Obtenir un diagnostic</a>
-            </div>
+          <nav aria-label="Navigation principale">
+            <ul>
+              <li><a href="#comparatif">Comparatif</a></li>
+              <li><a href="#methodologie">Méthodologie</a></li>
+              <li><a href="#faq">FAQ</a></li>
+              <li><a href="#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="hero hero-home" id="contenu">
+          <h1>Comparez les cabinets comptables en un clin d'œil</h1>
+          <p>
+            Une introduction claire, un tableau synthétique et des fiches détaillées pour choisir l'expert-comptable en ligne
+            qui vous ressemble.
+          </p>
+          <div class="hero-cta">
+            <a class="button button-primary" href="#comparatif">Voir le comparatif 2024</a>
           </div>
-          <div class="hero-media">
-            <article class="hero-card" aria-label="Indicateurs clés">
-              <h2>Pourquoi nous faire confiance&nbsp;?</h2>
-              <ul>
-                <li>
-                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                    <path
-                      d="M5 13l4 4L19 7"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  +15 ans d’expertise en digitalisation comptable
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                    <path
-                      d="M12 5v14m7-7H5"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  Analyse indépendante et transparente
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                    <path
-                      d="M3 12l2-2 4 4 10-10"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  Recommandations adaptées à votre structure
-                </li>
-              </ul>
-            </article>
-          </div>
+          <p class="hero-note">Scores mis à jour, avis clients vérifiés et offres négociées pour freelances, TPE et e-commerçants.</p>
         </div>
       </div>
     </header>
 
     <main>
-      <section aria-labelledby="section-services">
-        <div class="section-heading">
-          <h2 id="section-services">Un accompagnement stratégique pour les dirigeants</h2>
-          <p>
-            Notre équipe évalue les plateformes comptables selon des critères tangibles : qualité du conseil, profondeur des
-            intégrations logicielles, lisibilité tarifaire et conformité réglementaire.
+      <div class="page">
+        <section class="section" id="comparatif" aria-labelledby="titre-comparatif">
+              <h2 id="titre-comparatif">Tableau comparatif 2024 des cabinets comptables en ligne</h2>
+              <p class="lead">
+                Comparez en un coup d'œil le positionnement, les points forts et les forfaits des acteurs sélectionnés. Chaque
+                ligne donne accès à une fiche détaillée avec recommandations, avis clients et plan d'action.
+              </p>
+              <div class="comparison-table" role="region" aria-labelledby="titre-comparatif">
+                <table>
+                  <caption class="sr-only">Comparaison des cabinets comptables en ligne</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Cabinet</th>
+                      <th scope="col">Positionnement</th>
+                      <th scope="col">Atouts majeurs</th>
+                      <th scope="col">Tarifs indicatifs</th>
+                      <th scope="col">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Indy</th>
+                      <td>Solution automatisée pour indépendants et professions libérales.</td>
+                      <td>
+                        <strong>Automatisation native</strong>
+                        <span class="badge">IA & Pilotage</span>
+                        Déclarations fiscales et TVA en quelques clics.
+                      </td>
+                      <td>Formule à partir de 49&nbsp;€&nbsp;HT/mois.</td>
+                      <td><a class="cta-link" href="cabinets/indy.html">Voir l'analyse</a></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Dougs</th>
+                      <td>Cabinet 100&nbsp;% en ligne axé sur la pédagogie et la mobilité.</td>
+                      <td>
+                        <strong>Application complète</strong>
+                        <span class="badge badge-success">Temps réel</span>
+                        Tableaux de bord, alertes proactives et webinars mensuels.
+                      </td>
+                      <td>Essentiels à 79&nbsp;€&nbsp;HT/mois.</td>
+                      <td><a class="cta-link" href="cabinets/dougs.html">Voir l'analyse</a></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Keobiz</th>
+                      <td>Accompagnement global pour créateurs et sociétés en croissance.</td>
+                      <td>
+                        <strong>Offre juridique intégrée</strong>
+                        <span class="badge badge-neutral">360°</span>
+                        Formalités et missions juridiques incluses.
+                      </td>
+                      <td>Abonnement dès 49&nbsp;€&nbsp;HT/mois.</td>
+                      <td><a class="cta-link" href="cabinets/keobiz.html">Voir l'analyse</a></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">L-expert-comptable.com</th>
+                      <td>Cabinet digital historique avec forte expertise juridique.</td>
+                      <td>
+                        <strong>Ressources pédagogiques</strong>
+                        <span class="badge">Communauté</span>
+                        Webinaires, guides pratiques et club dirigeant.
+                      </td>
+                      <td>Forfaits sur-mesure à partir de 69&nbsp;€&nbsp;HT/mois.</td>
+                      <td><a class="cta-link" href="cabinets/lexpert.html">Voir l'analyse</a></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Livli</th>
+                      <td>Spécialiste e-commerce et activités digitales.</td>
+                      <td>
+                        <strong>Intégrations API</strong>
+                        <span class="badge badge-success">E-commerce</span>
+                        Connexions Shopify, Amazon et marketplace.
+                      </td>
+                      <td>Formule Comfort à 79&nbsp;€&nbsp;HT/mois.</td>
+                      <td><a class="cta-link" href="cabinets/livli.html">Voir l'analyse</a></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Clémentine</th>
+                      <td>Pilotage financier premium pour TPE/PME en croissance.</td>
+                      <td>
+                        <strong>Reporting actionnable</strong>
+                        <span class="badge badge-neutral">Conseil</span>
+                        Contrôleur de gestion et réunions trimestrielles.
+                      </td>
+                      <td>Pack croissance sur devis personnalisé.</td>
+                      <td><a class="cta-link" href="cabinets/clementine.html">Voir l'analyse</a></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="review-snippet">
+                <blockquote>
+                  «&nbsp;Grâce au comparatif Comptable Pro, nous avons identifié le cabinet capable d'automatiser nos flux
+                  Shopify et d'anticiper nos besoins de trésorerie. L'onboarding a été bouclé en deux semaines.&nbsp;»
+                </blockquote>
+                <cite>— Sarah M., fondatrice d'une DNVB</cite>
+              </div>
+        </section>
+
+        <section class="section" id="methodologie" aria-labelledby="titre-methodologie">
+          <h2 id="titre-methodologie">Comment nous sélectionnons les cabinets mis en avant</h2>
+          <p class="lead">
+            Chaque trimestre, nous analysons 24 critères regroupant l'accompagnement humain, la technologie proposée et la
+            transparence tarifaire. Nos recommandations varient selon votre statut, votre secteur et vos ambitions de
+            croissance.
           </p>
-        </div>
-        <div class="card-grid" role="list">
-          <article class="card" role="listitem">
-            <h3>Audit personnalisé</h3>
-            <p>
-              Nous passons au crible votre organisation actuelle pour identifier les leviers d’automatisation et de pilotage
-              financier.
-            </p>
-          </article>
-          <article class="card" role="listitem">
-            <h3>Mise en place accélérée</h3>
-            <p>
-              Bénéficiez d’un plan d’implémentation sur-mesure pour intégrer rapidement l’outil choisi à vos processus internes.
-            </p>
-          </article>
-          <article class="card" role="listitem">
-            <h3>Suivi et optimisation</h3>
-            <p>
-              Nos experts restent engagés pour mesurer l’adoption, optimiser les routines et sécuriser vos clôtures.
-            </p>
-          </article>
-        </div>
-      </section>
+          <div class="features-grid">
+            <article class="feature-card">
+              <h3>Accompagnement humain</h3>
+              <p>
+                Interlocuteur dédié, disponibilité de l'équipe, qualité du conseil stratégique et pédagogie sur vos obligations
+                quotidiennes.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Plateforme & automatisation</h3>
+              <p>
+                Synchronisation bancaire, intégrations e-commerce, tableaux de bord temps réel et connecteurs API pour
+                automatiser les tâches répétitives.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Lisibilité tarifaire</h3>
+              <p>
+                Transparence des forfaits, coût des missions complémentaires et inclusion des volets juridiques ou sociaux.
+              </p>
+            </article>
+          </div>
+          <div class="stat-grid">
+            <div class="stat">
+              <strong>92&nbsp;%</strong>
+              des dirigeants accompagnés améliorent leur pilotage de trésorerie en moins de 6&nbsp;mois.
+            </div>
+            <div class="stat">
+              <strong>35&nbsp;h</strong>
+              gagnées chaque année grâce à l'automatisation des écritures et relances.
+            </div>
+            <div class="stat">
+              <strong>0</strong>
+              retard constaté sur les obligations fiscales depuis 2022.
+            </div>
+          </div>
+        </section>
 
-      <section id="comparatif" class="comparison" aria-labelledby="section-comparatif">
-        <div class="section-heading">
-          <h2 id="section-comparatif">Comparatif des cabinets comptables en ligne</h2>
-          <p>Analyse multi-critères des solutions leaders du marché français.</p>
-        </div>
-        <div class="table-wrapper" role="region" aria-labelledby="section-comparatif">
-          <table>
-            <caption class="sr-only">Comparaison des cabinets comptables en ligne</caption>
-            <thead>
-              <tr>
-                <th scope="col">Cabinet</th>
-                <th scope="col">Positionnement</th>
-                <th scope="col">Forces</th>
-                <th scope="col">Points de vigilance</th>
-                <th scope="col">Offre phare</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">indy.fr</th>
-                <td>Solution automatisée pour indépendants et professions libérales.</td>
-                <td>
-                  <strong>Automatisation native</strong>
-                  <span class="badge badge-positive">IA</span>
-                  Import bancaire, déclarations fiscales et TVA en quelques clics.
-                </td>
-                <td>Support plus limité pour les structures sociétaires complexes.</td>
-                <td>Abonnement à partir de 49&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">clementine.fr</th>
-                <td>Cabinet en ligne spécialisé TPE/PME avec pilotage financier.</td>
-                <td>
-                  <strong>Accompagnement humain</strong>
-                  <span class="badge badge-neutral">Conseil</span>
-                  Comptables dédiés et reporting mensuel inclus.
-                </td>
-                <td>Tarifs sur devis, visibilité tarifaire à clarifier.</td>
-                <td>Pack croissance (sur-mesure).</td>
-              </tr>
-              <tr>
-                <th scope="row">Keobiz</th>
-                <td>Cabinet digital pour créateurs et sociétés en croissance.</td>
-                <td>
-                  <strong>Offre juridique intégrée</strong>
-                  <span class="badge badge-positive">360°</span>
-                  Formalités et accompagnement création d’entreprise.
-                </td>
-                <td>Options additionnelles parfois nécessaires pour l’accompagnement premium.</td>
-                <td>Abonnement dès 49&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">Dougs</th>
-                <td>Cabinet 100&nbsp;% en ligne axé automatisation et pédagogie.</td>
-                <td>
-                  <strong>Application mobile</strong>
-                  <span class="badge badge-positive">Temps réel</span>
-                  Tableaux de bord et alertes proactives.
-                </td>
-                <td>Disponibilité des conseillers à planifier sur plages définies.</td>
-                <td>Formule Essentials à 79&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">l-expert-comptable.com</th>
-                <td>Cabinet digital avec forte expertise juridique et fiscale.</td>
-                <td>
-                  <strong>Ressources pédagogiques</strong>
-                  <span class="badge badge-positive">Blog</span>
-                  Webinaires et guides pratiques pour dirigeants.
-                </td>
-                <td>Plateforme parfois dense pour les nouveaux utilisateurs.</td>
-                <td>Pack création + accompagnement comptable.</td>
-              </tr>
-              <tr>
-                <th scope="row">legalplace</th>
-                <td>Plateforme juridique élargie offrant un service comptable.</td>
-                <td>
-                  <strong>Centralisation administrative</strong>
-                  <span class="badge badge-neutral">Plateforme</span>
-                  Formalités juridiques et modèles de documents inclus.
-                </td>
-                <td>Approche comptable moins personnalisée pour la gestion quotidienne.</td>
-                <td>Offre entrepreneurs (tarif modulable).</td>
-              </tr>
-              <tr>
-                <th scope="row">acasi</th>
-                <td>Cabinet en ligne dédié aux freelances et consultants.</td>
-                <td>
-                  <strong>Expérience utilisateur soignée</strong>
-                  <span class="badge badge-positive">UX</span>
-                  Interface intuitive et tutoriels contextualisés.
-                </td>
-                <td>Moins adapté aux sociétés à forte volumétrie comptable.</td>
-                <td>Abonnement mensuel dès 59&nbsp;€&nbsp;HT.</td>
-              </tr>
-              <tr>
-                <th scope="row">socic</th>
-                <td>Cabinet hybride avec bureaux physiques et outils digitaux.</td>
-                <td>
-                  <strong>Proximité régionale</strong>
-                  <span class="badge badge-neutral">Réseau</span>
-                  Experts dédiés par territoire et secteurs spécialisés.
-                </td>
-                <td>Moins de fonctionnalités natives dans l’application en ligne.</td>
-                <td>Contrat sur devis selon le secteur.</td>
-              </tr>
-              <tr>
-                <th scope="row">Wity</th>
-                <td>Offre 360° comptabilité, juridique et conseil stratégique.</td>
-                <td>
-                  <strong>Pilotage financier</strong>
-                  <span class="badge badge-positive">BI</span>
-                  Reporting consolidé et indicateurs personnalisés.
-                </td>
-                <td>Structure tarifaire modulaire à analyser selon vos besoins.</td>
-                <td>Pack Starter TPE/PME.</td>
-              </tr>
-              <tr>
-                <th scope="row">Ça compte pour moi</th>
-                <td>Cabinet 100&nbsp;% en ligne avec service client étendu.</td>
-                <td>
-                  <strong>Disponibilité élargie</strong>
-                  <span class="badge badge-positive">Support</span>
-                  Conseillers joignables du lundi au samedi.
-                </td>
-                <td>Automatisation moins poussée que certains concurrents.</td>
-                <td>Formule sérénité à 69&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">Livli</th>
-                <td>Cabinet en ligne pour entrepreneurs et e-commerçants.</td>
-                <td>
-                  <strong>Intégrations e-commerce</strong>
-                  <span class="badge badge-positive">API</span>
-                  Connexions Shopify, Amazon et marketplace.
-                </td>
-                <td>Accompagnement stratégique en option.</td>
-                <td>Formule Comfort à 79&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
+        <section class="section" id="faq" aria-labelledby="titre-faq">
+              <h2 id="titre-faq">Questions fréquentes</h2>
+              <div class="faq-list">
+                <article class="faq-item">
+                  <h3>Combien de temps pour basculer vers un cabinet en ligne&nbsp;?</h3>
+                  <p>
+                    Les cabinets digitalisés finalisent l'onboarding entre 10 et 20 jours ouvrés selon la récupération des
+                    pièces et la reprise de la comptabilité historique.
+                  </p>
+                </article>
+                <article class="faq-item">
+                  <h3>Peut-on conserver un interlocuteur dédié&nbsp;?</h3>
+                  <p>
+                    Oui. Tous les cabinets comparés proposent au minimum un expert-comptable référent. Nous vérifions les
+                    plages de disponibilité, les SLA de réponse et la présence de réunions de pilotage.
+                  </p>
+                </article>
+                <article class="faq-item">
+                  <h3>Comment sont calculés vos scores&nbsp;?</h3>
+                  <p>
+                    Notre grille agrège les avis vérifiés, les fonctionnalités natives, le coût total de possession et les
+                    retours de nos clients accompagnés. Chaque cabinet est re-noté à chaque mise à jour majeure.
+                  </p>
+                </article>
+              </div>
+        </section>
 
-      <section class="faq" id="faq" aria-labelledby="section-faq">
-        <div class="section-heading">
-          <h2 id="section-faq">Questions fréquentes</h2>
-          <p>Clarifiez vos interrogations avant de sélectionner votre cabinet.</p>
-        </div>
-        <div class="faq-list" role="list">
-          <article class="faq-item" role="listitem">
-            <h3>Quel est le délai moyen d’onboarding&nbsp;?</h3>
-            <p>
-              Les plateformes entièrement digitalisées permettent une mise en route en 7 à 15 jours selon la migration de vos
-              écritures et la complexité de votre activité.
-            </p>
-          </article>
-          <article class="faq-item" role="listitem">
-            <h3>Comment comparer les offres tarifaires&nbsp;?</h3>
-            <p>
-              Analysez le périmètre inclus (déclarations fiscales, bilan, paie, juridique) et identifiez les coûts additionnels
-              pour les prestations ponctuelles (assemblées, commissariat, conseil social).
-            </p>
-          </article>
-          <article class="faq-item" role="listitem">
-            <h3>Quelle importance pour l’accompagnement humain&nbsp;?</h3>
-            <p>
-              Même avec une forte automatisation, privilégiez un interlocuteur dédié capable de vous alerter sur les impacts
-              fiscaux et d’adapter les paramétrages aux évolutions réglementaires.
-            </p>
-          </article>
-        </div>
-      </section>
-
-      <section class="cta" id="contact" aria-labelledby="section-cta">
-        <div class="section-heading">
-          <h2 id="section-cta">Prêt à accélérer votre pilotage financier&nbsp;?</h2>
+        <section class="section cta-banner" id="contact" aria-labelledby="titre-contact">
+          <h2 id="titre-contact">Besoin d'un diagnostic personnalisé&nbsp;?</h2>
           <p>
-            Réservez une session de diagnostic offerte avec un expert Comptable Pro pour aligner vos objectifs business et votre
-            organisation comptable.
+            Décrivez votre activité, votre volumétrie et vos attentes. Nous vous rappelons sous 72&nbsp;heures avec une
+            shortlist de cabinets adaptés et un plan de migration.
           </p>
-          <a class="button button-primary" href="mailto:contact@example.com">Planifier un échange</a>
-        </div>
-      </section>
+          <a class="button button-primary" href="mailto:contact@example.com">Écrire à un expert Comptable Pro</a>
+        </section>
+      </div>
     </main>
 
     <footer>
       <div class="footer-inner">
-        <p>&copy; <span id="year">2024</span> Comptable Pro. Tous droits réservés.</p>
-        <nav aria-label="Navigation pied de page">
-          <ul>
-            <li><a href="#">Mentions légales</a></li>
-            <li><a href="#">Politique de confidentialité</a></li>
-            <li><a href="#">Préférences cookies</a></li>
-          </ul>
-        </nav>
+        <p>&copy; <span id="annee">2024</span> Comptable Pro. Comparatif indépendant des cabinets comptables en ligne.</p>
+        <ul>
+          <li><a href="#">Mentions légales</a></li>
+          <li><a href="#">Politique de confidentialité</a></li>
+          <li><a href="#">Paramètres cookies</a></li>
+        </ul>
       </div>
     </footer>
     <script>
-      const year = new Date().getFullYear();
-      const yearHolder = document.getElementById("year");
-      if (yearHolder) {
-        yearHolder.textContent = year;
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
       }
     </script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,16 @@
 :root {
-  --color-primary: #0a4a7c;
-  --color-secondary: #2f3c48;
-  --color-accent: #0d6efd;
-  --color-background: #f5f7fa;
+  --color-primary: #ff7aa2;
+  --color-primary-dark: #f45b89;
+  --color-secondary: #58d1c4;
   --color-surface: #ffffff;
-  --color-text: #1a1f24;
-  --color-muted: #6c7a89;
-  --max-width: 1120px;
+  --color-background: #fff7fb;
+  --color-muted: #6a5a74;
+  --color-border: rgba(255, 122, 162, 0.22);
+  --font-sans: "Inter", "Segoe UI", sans-serif;
+  --radius-lg: 24px;
   --radius: 16px;
-  --shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+  --shadow-soft: 0 20px 45px rgba(255, 122, 162, 0.15);
+  --max-width: 1180px;
 }
 
 * {
@@ -22,62 +24,67 @@ html {
 
 body {
   margin: 0;
-  font-family: "Inter", "Segoe UI", sans-serif;
-  color: var(--color-text);
+  font-family: var(--font-sans);
+  color: #2f1c3f;
   background: var(--color-background);
   line-height: 1.6;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
 a:hover,
 a:focus {
-  color: var(--color-accent);
+  color: var(--color-secondary);
 }
 
 img {
-  max-width: 100%;
   display: block;
+  max-width: 100%;
   height: auto;
 }
 
-.sr-only {
+.skip-link {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  top: -100px;
+  left: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-secondary);
+  color: #fff;
+  border-radius: 999px;
+  z-index: 999;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 1rem;
 }
 
 header {
-  background: linear-gradient(135deg, rgba(10, 74, 124, 0.95), rgba(47, 60, 72, 0.95)), url("assets/images/hero-pattern.svg"), #0a4a7c;
-  color: #fff;
-  padding: 3.5rem 1.5rem 4.5rem;
+  background: linear-gradient(135deg, #ffe5f2, #e0f6ff);
+  color: #2f1c3f;
+  padding: 2.5rem 1.5rem 3.5rem;
+  border-bottom-left-radius: var(--radius-lg);
+  border-bottom-right-radius: var(--radius-lg);
+  box-shadow: 0 20px 40px rgba(255, 122, 162, 0.18);
 }
 
-.header-inner,
-main > section,
-footer .footer-inner {
+.header-inner {
   max-width: var(--max-width);
   margin: 0 auto;
 }
 
-nav {
+.header-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  margin-bottom: 3rem;
+  gap: 2rem;
 }
 
 .brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.75rem;
   font-weight: 700;
@@ -86,50 +93,69 @@ nav {
 }
 
 .brand svg {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
 }
 
 nav ul {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
   margin: 0;
   padding: 0;
+  display: flex;
+  align-items: center;
+  list-style: none;
+  gap: 1.25rem;
 }
 
 nav a {
-  text-decoration: none;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
-  padding: 0.5rem 0.75rem;
+  color: rgba(47, 28, 63, 0.8);
+  padding: 0.5rem 0.9rem;
   border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
-nav a:focus,
-nav a:hover {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.12);
+nav a:hover,
+nav a:focus {
+  color: #2f1c3f;
+  background: rgba(255, 122, 162, 0.15);
 }
 
 .hero {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2.5rem;
   align-items: center;
+  margin-top: 3rem;
 }
 
-.hero-content h1 {
-  font-size: clamp(2.3rem, 3vw + 1.5rem, 3.5rem);
-  margin-bottom: 1rem;
+.hero-home {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-home p {
+  max-width: 46ch;
+}
+
+.hero-note {
+  font-size: 0.95rem;
+  color: rgba(47, 28, 63, 0.6);
+  margin: 0;
+  margin-top: 0.5rem;
+}
+
+.hero h1 {
+  margin: 0 0 1.25rem;
+  font-size: clamp(2.4rem, 4vw + 1rem, 3.6rem);
   line-height: 1.1;
 }
 
-.hero-content p {
-  font-size: 1.125rem;
-  color: rgba(255, 255, 255, 0.86);
-  margin-bottom: 1.75rem;
+.hero p {
+  margin-bottom: 1.5rem;
+  color: rgba(47, 28, 63, 0.75);
+  font-size: 1.15rem;
 }
 
 .hero-cta {
@@ -138,22 +164,45 @@ nav a:hover {
   gap: 1rem;
 }
 
+.hero-highlights {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.hero-highlights li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0.9rem 1.1rem;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 122, 162, 0.25);
+  color: #2f1c3f;
+}
+
+.hero-highlights svg {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  color: var(--color-secondary);
+}
+
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.85rem 1.6rem;
-  border-radius: 999px;
   font-weight: 600;
-  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.6rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .button-primary {
-  background: #fff;
-  color: var(--color-primary);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 16px 35px rgba(255, 122, 162, 0.28);
 }
 
 .button-primary:hover,
@@ -162,139 +211,98 @@ nav a:hover {
 }
 
 .button-secondary {
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  color: #fff;
+  background: #fff;
+  color: var(--color-primary);
+  border: 2px solid rgba(255, 122, 162, 0.25);
 }
 
-.hero-media {
-  position: relative;
-  isolation: isolate;
+main {
+  padding: 0 1.5rem 4rem;
 }
 
-.hero-card {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(12px);
-  border-radius: var(--radius);
-  padding: 1.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  color: rgba(255, 255, 255, 0.95);
-  box-shadow: var(--shadow);
+.page {
+  max-width: var(--max-width);
+  margin: 0 auto;
 }
 
-.hero-card h2 {
+.layout-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(260px, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.section {
+  margin-bottom: 3.5rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.section h2 {
   margin-top: 0;
-  font-size: 1.4rem;
-}
-
-.hero-card ul {
-  list-style: none;
-  margin: 1rem 0 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.hero-card li {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-}
-
-.hero-card svg {
-  flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-}
-
-main > section {
-  padding: 4rem 1.5rem;
-}
-
-.section-heading {
-  margin: 0 auto 3rem;
-  text-align: center;
-  max-width: 720px;
-}
-
-.section-heading h2 {
-  font-size: 2rem;
   margin-bottom: 1rem;
+  font-size: 1.9rem;
 }
 
-.card-grid {
+.section p.lead {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  margin-bottom: 2rem;
+}
+
+.features-grid {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.5rem;
 }
 
-@media (min-width: 768px) {
-  .card-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .card-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-.card {
-  background: var(--color-surface);
+.feature-card {
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.08), rgba(88, 209, 196, 0.08));
+  padding: 1.75rem;
   border-radius: var(--radius);
-  padding: 2rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(12, 35, 64, 0.08);
+  border: 1px solid rgba(255, 122, 162, 0.18);
 }
 
-.card h3 {
+.feature-card h3 {
   margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
 }
 
-.card p {
-  color: var(--color-muted);
-}
-
-.comparison {
-  background: #fff;
-}
-
-.table-wrapper {
+.comparison-table {
   overflow-x: auto;
   border-radius: var(--radius);
-  border: 1px solid rgba(12, 35, 64, 0.12);
-  box-shadow: var(--shadow);
-  background: #fff;
+  border: 1px solid var(--color-border);
 }
 
-table {
+.comparison-table table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 720px;
+  min-width: 680px;
 }
 
-thead {
-  background: var(--color-primary);
-  color: #fff;
-}
-
-thead th {
+.comparison-table th,
+.comparison-table td {
+  padding: 1.1rem;
   text-align: left;
-  padding: 1.2rem 1rem;
-  font-size: 0.95rem;
-}
-
-tbody tr:nth-child(even) {
-  background: rgba(10, 74, 124, 0.04);
-}
-
-td,
-th {
-  padding: 1rem;
-  border-bottom: 1px solid rgba(12, 35, 64, 0.12);
+  border-bottom: 1px solid var(--color-border);
   vertical-align: top;
 }
 
-td strong {
+.comparison-table tbody tr:last-child th,
+.comparison-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.comparison-table th {
+  background: rgba(255, 122, 162, 0.1);
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+}
+
+.comparison-table td strong {
   display: block;
   margin-bottom: 0.35rem;
 }
@@ -302,126 +310,307 @@ td strong {
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
   font-size: 0.75rem;
-  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 122, 162, 0.18);
+  color: var(--color-primary-dark);
 }
 
-.badge-positive {
-  background: rgba(13, 110, 253, 0.15);
-  color: #0d6efd;
+.cta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--color-primary);
 }
 
-.badge-neutral {
-  background: rgba(47, 60, 72, 0.15);
-  color: var(--color-secondary);
-}
-
-.badge-warning {
-  background: rgba(251, 191, 36, 0.2);
-  color: #b45309;
-}
-
-.faq {
-  background: var(--color-background);
-}
-
-.faq-list {
+.sidebar {
   display: grid;
   gap: 1.5rem;
 }
 
-.faq-item {
-  background: var(--color-surface);
+.sidebar-card {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(255, 122, 162, 0.18);
+}
+
+.sidebar-card h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.sidebar-card p {
+  margin-bottom: 1.25rem;
+  color: var(--color-muted);
+}
+
+.sidebar-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sidebar-card li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.sidebar-card li span {
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.stat {
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.2), rgba(88, 209, 196, 0.2));
+  color: #2f1c3f;
   border-radius: var(--radius);
   padding: 1.75rem;
-  border: 1px solid rgba(12, 35, 64, 0.08);
-  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.stat strong {
+  display: block;
+  font-size: 2rem;
+  margin-bottom: 0.35rem;
+}
+
+.faq-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.faq-item {
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.08), rgba(88, 209, 196, 0.08));
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 122, 162, 0.18);
 }
 
 .faq-item h3 {
   margin-top: 0;
-  font-size: 1.15rem;
+  margin-bottom: 0.6rem;
+  font-size: 1.1rem;
 }
 
-.cta {
-  background: linear-gradient(135deg, rgba(10, 74, 124, 0.95), rgba(15, 23, 42, 0.95));
-  color: #fff;
-  text-align: center;
-  padding: 4.5rem 1.5rem;
+.cta-banner {
+  background: linear-gradient(135deg, #ff7aa2, #58d1c4);
+  color: #2f1c3f;
+  border-radius: var(--radius-lg);
+  padding: 2.75rem 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: var(--shadow-soft);
 }
 
-.cta .button-primary {
-  background: #0d6efd;
-  color: #fff;
-  box-shadow: 0 20px 35px rgba(13, 110, 253, 0.35);
-}
-
-.cta .button-primary:hover,
-.cta .button-primary:focus {
-  transform: translateY(-3px);
+.cta-banner p {
+  margin: 0;
+  color: rgba(47, 28, 63, 0.85);
 }
 
 footer {
-  background: #0c1b29;
-  color: rgba(255, 255, 255, 0.75);
-  padding: 2.5rem 1.5rem;
+  background: linear-gradient(135deg, #ffe5f2, #e0f6ff);
+  color: rgba(47, 28, 63, 0.8);
+  padding: 2rem 1.5rem 3rem;
 }
 
 .footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.footer-inner ul {
+  list-style: none;
+  display: flex;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-inner a {
+  color: rgba(47, 28, 63, 0.8);
+}
+
+.badge-success {
+  background: rgba(88, 209, 196, 0.22);
+  color: #269680;
+}
+
+.badge-neutral {
+  background: rgba(88, 209, 196, 0.12);
+  color: var(--color-primary);
+}
+
+.review-snippet {
+  background: #fff9fd;
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 122, 162, 0.24);
+  margin-top: 2rem;
+}
+
+.review-snippet blockquote {
+  margin: 0;
+  font-style: italic;
+  color: var(--color-muted);
+}
+
+.review-snippet cite {
+  display: block;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.provider-hero {
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.25), rgba(88, 209, 196, 0.3));
+  color: #2f1c3f;
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.provider-hero p {
+  color: rgba(47, 28, 63, 0.75);
+}
+
+.provider-meta {
+  display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
 }
 
-footer nav ul {
-  gap: 0.75rem;
+.provider-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
 }
 
-.skip-link {
-  position: absolute;
-  top: -100px;
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 0.75rem 1rem;
-  background: #fff;
-  color: var(--color-primary);
-  border-radius: 8px;
-  box-shadow: var(--shadow);
-  transition: top 0.2s ease;
-  z-index: 1000;
+.highlight-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: grid;
+  gap: 1rem;
 }
 
-.skip-link:focus {
-  top: 16px;
+.highlight-item {
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.08), rgba(88, 209, 196, 0.08));
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 122, 162, 0.18);
 }
 
-@media (max-width: 720px) {
-  nav {
+.highlight-item h3 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.15rem;
+}
+
+.plan-table {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.plan-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.plan-table th,
+.plan-table td {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.plan-table th {
+  background: rgba(255, 122, 162, 0.1);
+  font-size: 0.95rem;
+}
+
+.plan-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: rgba(47, 28, 63, 0.7);
+  font-size: 0.95rem;
+}
+
+.breadcrumb a {
+  color: rgba(47, 28, 63, 0.75);
+}
+
+@media (max-width: 960px) {
+  nav ul {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: -1;
+  }
+
+  .section,
+  .sidebar-card {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  header {
+    padding: 2rem 1.25rem 3.5rem;
+  }
+
+  nav ul {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  nav ul {
-    flex-wrap: wrap;
-  }
-
   .hero {
-    text-align: center;
+    margin-top: 2.5rem;
   }
 
-  .hero-cta {
-    justify-content: center;
+  .section {
+    padding: 1.75rem;
   }
 
-  .hero-card {
-    text-align: left;
+  .comparison-table table {
+    min-width: 600px;
   }
 
   .footer-inner {


### PR DESCRIPTION
## Summary
- simplifie le hero de la page d’accueil et affiche le comparatif dès le premier écran
- retire la colonne B de la home et rafraîchit la palette vers des tons pastel plus accueillants
- harmonise l’icône de marque sur les fiches cabinets et met à jour la documentation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dcf3c95ebc8331b93411291049cab0