### PR TITLE
Affiner les contenus et les plans d’onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# comptable
+# Comptable Pro
+
+Site vitrine statique qui compare les principaux cabinets comptables en ligne. La page d'accueil affiche un hero condensé, le tableau comparatif et un menu inspiré d'envoi-de-fleurs.fr avec accès rapide aux fiches et au classement des prix. Chaque cabinet dispose d'une fiche individuelle sans colonne latérale mais avec CTA affilié et points clés synthétiques.
+
+## Structure
+- `index.html` : page d'accueil avec comparatif, méthodologie, FAQ et contact.
+- `les-moins-chers.html` : classement des cabinets par prix décroissant.
+- `cabinets/` : fiches détaillées (Indy, Dougs, Keobiz, L-expert-comptable.com, Livli, Clémentine).
+- `styles.css` : feuille de style globale responsive inspirée des codes graphiques d'envoi-de-fleurs.fr.
+- `assets/` : éléments graphiques.
+
+## Prévisualisation locale
+```bash
+# depuis le dossier du projet
+python -m http.server 8000
+```
+Puis ouvrez `http://localhost:8000/index.html` dans votre navigateur.
+
+Le site est responsive et pensé pour une expérience mobile et desktop.

--- a/cabinets/clementine.html
+++ b/cabinets/clementine.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clémentine : cabinet comptable premium pour scale-up | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Découvrez l'offre Clémentine : pilotage financier, reporting et accompagnement stratégique pour TPE/PME en croissance."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="../les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-provider">
+        <div class="content-area">
+          <section class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Clémentine</span>
+            </div>
+            <h1>Clémentine&nbsp;: du pilotage financier au conseil stratégique</h1>
+            <p>
+              Cabinet premium dédié aux entreprises en croissance, Clémentine combine expertise comptable, contrôle de gestion et
+              stratégie financière pour accélérer vos décisions.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,8/5</span>
+              <span><strong>Clients types</strong> Scale-up, PME multi-sites</span>
+              <span><strong>Onboarding</strong> 20 jours ouvrés</span>
+            </div>
+            <ul class="hero-highlights" role="list">
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M5 12l4 4 10-10"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Contrôleur de gestion dédié et reportings sur mesure
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M12 6v12m6-6H6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Accompagnement sur la structuration de la finance d'entreprise (BI, KPI, levée de fonds)
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Squad pluridisciplinaire (comptables, DAF à temps partagé, juristes)
+              </li>
+            </ul>
+          </section>
+
+          <section class="section provider-insights" aria-labelledby="clementine-insights">
+            <h2 id="clementine-insights">Points clés Clémentine</h2>
+            <div class="insight-grid">
+              <article class="insight-card">
+                <h3>Session diagnostic</h3>
+                <p>Planifiez un diagnostic financier avec un DAF à temps partagé pour cartographier vos enjeux.</p>
+                <ul class="insight-list">
+                  <li><span>Délai</span>72&nbsp;h</li>
+                  <li><span>Durée</span>1&nbsp;h</li>
+                  <li><span>Format</span>Visio stratégique</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Profil idéal</h3>
+                <ul class="insight-list">
+                  <li><span>CA</span>&gt; 2&nbsp;M€</li>
+                  <li><span>Équipe</span>Finance interne</li>
+                  <li><span>Objectif</span>Structurer la fonction finance</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Documents à préparer</h3>
+                <p>Rassemblez business plan, reporting actuel et projections pour accélérer l'onboarding.</p>
+                <a class="cta-link" href="https://www.clementine.pro/ressources/" target="_blank" rel="noopener">Télécharger la trame</a>
+              </article>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="clementine-forces">
+            <h2 id="clementine-forces">Forces clés de Clémentine</h2>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Pilotage financier sur mesure</h3>
+                <p>Élaboration de tableaux de bord personnalisés, suivi de KPIs et scénarios budgétaires adaptés à vos enjeux de croissance.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Accompagnement stratégique</h3>
+                <p>Conseil en levée de fonds, structuration de la fonction finance et accompagnement sur les opérations de M&amp;A.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Gestion multi-sites</h3>
+                <p>Processus éprouvés pour consolider les données financières de plusieurs établissements et garantir une vision groupe.</p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="clementine-tarifs">
+            <h2 id="clementine-tarifs">Tarifs Clémentine</h2>
+            <div class="plan-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Formule</th>
+                    <th scope="col">Contenu</th>
+                    <th scope="col">Prix</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Pack Croissance</th>
+                    <td>Tenue comptable, bilans, réunions de pilotage trimestrielles</td>
+                    <td>Sur devis (à partir de 249&nbsp;€&nbsp;HT/mois)</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Pack Scale-up</th>
+                    <td>DAF à temps partagé, reporting investisseurs, scénarios budgétaires</td>
+                    <td>Sur devis</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Pack Transaction</th>
+                    <td>Due diligence, valorisation, accompagnement levée de fonds</td>
+                    <td>Honoraires selon mission</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="clementine-vigilance">
+            <h2 id="clementine-vigilance">Points de vigilance</h2>
+            <p class="lead">
+              Clémentine s'adresse aux structures ambitieuses. Assurez-vous d'avoir une équipe interne disponible pour tirer parti des
+              ateliers stratégiques proposés.
+            </p>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Disponibilité des équipes</h3>
+                <p>Les sessions de pilotage nécessitent l'implication de la direction et des managers pour être efficaces.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Budget</h3>
+                <p>Positionnement premium&nbsp;: prévoyez un budget supérieur aux cabinets automatisés pour bénéficier du conseil stratégique.</p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="clementine-plan">
+            <h2 id="clementine-plan">Plan d'action Clémentine</h2>
+            <ol class="timeline timeline-compact" aria-label="Plan d'onboarding Clémentine">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Atelier vision</strong>
+                  <p>Organisez un workshop avec le DAF à temps partagé pour aligner vos objectifs financiers et extra-financiers.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Structuration data</strong>
+                  <p>Centralisez vos tableaux de bord, fichiers trésorerie et CRM pour alimenter le reporting Clémentine.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Rituels de pilotage</strong>
+                  <p>Mettez en place les comités mensuels et trimestriels pour suivre cash, marge et roadmap stratégique.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions Clémentine">
+          <div class="sidebar-card">
+            <h2>Rencontrer Clémentine</h2>
+            <p>Réservez une session diagnostic avec un DAF à temps partagé pour cadrer vos priorités financières.</p>
+            <a
+              class="button button-primary"
+              href="https://www.clementine.pro/?utm_source=comptablepro&amp;utm_medium=fiche"
+              target="_blank"
+              rel="noopener nofollow"
+              >Visiter le site Clémentine &raquo;</a
+            >
+          </div>
+          <div class="sidebar-card">
+            <h2>En résumé</h2>
+            <ul class="sidebar-list" role="list">
+              <li><strong>Score :</strong> 4,8/5</li>
+              <li><strong>Clients :</strong> Scale-up, PME</li>
+              <li><strong>Onboarding :</strong> 20 jours</li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Checklist onboarding</h2>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Partager votre business plan et votre forecast trésorerie.</li>
+              <li><span class="sidebar-step-index">2</span>Identifier les KPI prioritaires (MRR, marge, cash).</li>
+              <li><span class="sidebar-step-index">3</span>Nommer un référent interne pour coordonner les rituels.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Étudier votre cas</h2>
+            <p>Partagez votre business plan et vos enjeux : nous vous aidons à structurer la mission idéale avec Clémentine.</p>
+            <a class="button button-secondary" href="mailto:contact@example.com">Échanger avec nous</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/cabinets/dougs.html
+++ b/cabinets/dougs.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dougs : avis et analyse du cabinet comptable en ligne | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Analyse complète de Dougs : fonctionnalités, accompagnement, tarifs et points d'attention pour choisir ce cabinet comptable en ligne."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="../les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-provider">
+        <div class="content-area">
+          <section class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Dougs</span>
+            </div>
+            <h1>Dougs&nbsp;: la pédagogie comptable 100&nbsp;% en ligne</h1>
+            <p>
+              Dougs combine une application mobile complète, des webinars réguliers et un accompagnement humain structuré pour aider
+              les dirigeants à prendre des décisions éclairées.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,6/5</span>
+              <span><strong>Clients types</strong> SASU, SARL, professions libérales</span>
+              <span><strong>Onboarding</strong> 12 jours ouvrés</span>
+            </div>
+            <ul class="hero-highlights" role="list">
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M5 12l4 4 10-10"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Tableaux de bord de trésorerie et alertes personnalisées
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M12 6v12m6-6H6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Parcours d'onboarding en vidéos pour comprendre chaque étape
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Option sociale et juridique intégrée pour gérer vos obligations
+              </li>
+            </ul>
+          </section>
+
+          <section class="section provider-insights" aria-labelledby="dougs-insights">
+            <h2 id="dougs-insights">Points clés Dougs</h2>
+            <div class="insight-grid">
+              <article class="insight-card">
+                <h3>Démo guidée</h3>
+                <p>Réservez une présentation pour découvrir les tableaux de bord et poser vos questions en direct.</p>
+                <ul class="insight-list">
+                  <li><span>Délai</span>48&nbsp;h</li>
+                  <li><span>Durée</span>45&nbsp;min</li>
+                  <li><span>Support</span>Visio + replay</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Profil idéal</h3>
+                <ul class="insight-list">
+                  <li><span>Statut</span>SASU / SARL</li>
+                  <li><span>Équipe</span>1 à 20 salariés</li>
+                  <li><span>Besoin</span>Reporting dynamique</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Aller plus loin</h3>
+                <p>Consultez les retours d'expérience de clients Dougs pour confirmer l'adéquation sectorielle.</p>
+                <a class="cta-link" href="https://www.dougs.fr/blog/" target="_blank" rel="noopener">Accéder au blog</a>
+              </article>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="dougs-forces">
+            <h2 id="dougs-forces">Forces clés de Dougs</h2>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Vision financière en temps réel</h3>
+                <p>
+                  L'application propose des graphiques de trésorerie, un prévisionnel et des alertes personnalisées sur vos indicateurs
+                  clés.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Accompagnement pédagogique</h3>
+                <p>
+                  Les webinars, articles et check-lists aident les dirigeants à comprendre la comptabilité et à anticiper leurs obligations.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Offre sociale et juridique intégrée</h3>
+                <p>
+                  Dougs propose des options paie et juridique pour centraliser vos obligations administratives auprès d'un seul interlocuteur.
+                </p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="dougs-tarifs">
+            <h2 id="dougs-tarifs">Tarifs et forfaits Dougs</h2>
+            <div class="plan-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Formule</th>
+                    <th scope="col">Contenu</th>
+                    <th scope="col">Prix</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Essentiel</th>
+                    <td>Tenue comptable, bilans, application mobile, support illimité</td>
+                    <td>79&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Premium</th>
+                    <td>Accompagnement renforcé, rendez-vous stratégiques, fiscalité patrimoniale</td>
+                    <td>119&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Option sociale</th>
+                    <td>Production de bulletins, déclarations sociales, conseil RH</td>
+                    <td>25&nbsp;€&nbsp;HT/mois / salarié</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="dougs-vigilance">
+            <h2 id="dougs-vigilance">Points de vigilance</h2>
+            <p class="lead">
+              Dougs s'adresse aux dirigeants autonomes souhaitant piloter leur activité via une application complète. Les structures très
+              complexes devront valider la couverture des cas particuliers.
+            </p>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Processus dématérialisés</h3>
+                <p>
+                  L'essentiel des échanges se fait via l'application et le chat. Vérifiez l'adéquation avec votre besoin de rendez-vous
+                  physiques.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Gestion multi-sociétés</h3>
+                <p>
+                  Dougs convient aux dirigeants multi-structures, mais certains reports consolidés nécessitent des exports et retraitements
+                  externes.
+                </p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="dougs-plan">
+            <h2 id="dougs-plan">Plan d'action Dougs</h2>
+            <ol class="timeline timeline-compact" aria-label="Plan d'onboarding Dougs">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Réservez une visio diagnostic</strong>
+                  <p>Présentez vos outils actuels pour calibrer la lettre de mission et valider le périmètre juridique/social.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Synchronisez vos flux</strong>
+                  <p>Activez la banque, importez vos factures et configurez l'application mobile pour les justificatifs.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Fixez vos rituels</strong>
+                  <p>Planifiez un point mensuel avec le conseiller Dougs et activez les webinars adaptés à votre secteur.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions Dougs">
+          <div class="sidebar-card">
+            <h2>Tester Dougs</h2>
+            <p>Demandez une démo personnalisée et profitez d'un onboarding accompagné par un coach Dougs.</p>
+            <a
+              class="button button-primary"
+              href="https://www.dougs.fr/?utm_source=comptablepro&amp;utm_medium=fiche"
+              target="_blank"
+              rel="noopener nofollow"
+              >Visiter le site Dougs &raquo;</a
+            >
+          </div>
+          <div class="sidebar-card">
+            <h2>En résumé</h2>
+            <ul class="sidebar-list" role="list">
+              <li><strong>Score :</strong> 4,6/5</li>
+              <li><strong>Clients :</strong> SASU, SARL</li>
+              <li><strong>Onboarding :</strong> 12 jours</li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Checklist onboarding</h2>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Partager vos accès bancaires et outils de facturation.</li>
+              <li><span class="sidebar-step-index">2</span>Uploader vos justificatifs dans la Dougs Box.</li>
+              <li><span class="sidebar-step-index">3</span>Valider la date de production du premier bilan.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Besoin d'un avis humain ?</h2>
+            <p>Expliquez vos enjeux à Comptable Pro pour valider l'adéquation de Dougs avec votre secteur.</p>
+            <a class="button button-secondary" href="mailto:contact@example.com">Planifier un appel</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/cabinets/indy.html
+++ b/cabinets/indy.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Indy : notre avis sur le cabinet comptable en ligne | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Découvrez l'analyse complète d'Indy : automatisation comptable, accompagnement, tarifs et points de vigilance pour indépendants."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="../les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-provider">
+        <div class="content-area">
+          <section class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Indy</span>
+            </div>
+            <h1>Indy&nbsp;: l'automatisation comptable pour les indépendants</h1>
+            <p>
+              Plateforme conçue pour les professions libérales, freelances et micro-entrepreneurs qui souhaitent automatiser la
+              tenue comptable, sécuriser leurs déclarations et gagner du temps sur l'administratif.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,7/5</span>
+              <span><strong>Clients types</strong> BNC, BIC, SCM</span>
+              <span><strong>Onboarding</strong> 7 jours ouvrés</span>
+            </div>
+            <ul class="hero-highlights" role="list">
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M12 6v12m6-6H6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Déclarations fiscales pré-remplies (2035, TVA) et rappels automatisés
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M5 12l4 4 10-10"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Application mobile pour scanner les justificatifs en temps réel
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Bibliothèque de guides et webinars pédagogiques accessibles 24/7
+              </li>
+            </ul>
+          </section>
+
+          <section class="section provider-insights" aria-labelledby="indy-insights">
+            <h2 id="indy-insights">Points clés Indy</h2>
+            <div class="insight-grid">
+              <article class="insight-card">
+                <h3>Démo accompagnée</h3>
+                <p>Planifiez un rendez-vous découverte avec un conseiller Indy pour valider votre cas d'usage.</p>
+                <ul class="insight-list">
+                  <li><span>Délai</span>24&nbsp;h</li>
+                  <li><span>Durée</span>30&nbsp;min</li>
+                  <li><span>Format</span>Visio personnalisée</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Profil idéal</h3>
+                <ul class="insight-list">
+                  <li><span>Statut</span>BNC / Freelance</li>
+                  <li><span>Logiciel actuel</span>Excel / Tableur</li>
+                  <li><span>Objectif</span>Automatiser 90&nbsp;% des tâches</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Prochaines étapes</h3>
+                <p>Préparez vos accès bancaires et vos déclarations précédentes pour accélérer la migration.</p>
+                <a class="cta-link" href="../index.html#contact">Parler à un expert Comptable Pro</a>
+              </article>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="indy-forces">
+            <h2 id="indy-forces">Forces clés d'Indy</h2>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Automatisation poussée</h3>
+                <p>
+                  Synchronisation bancaire instantanée, catégorisation automatique des opérations et génération de la liasse fiscale
+                  en un clic.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Accompagnement fiscal</h3>
+                <p>
+                  Conseillers spécialisés BNC disponibles par chat et téléphone pour sécuriser les déclarations complexes et anticiper
+                  les optimisations.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Expérience utilisateur</h3>
+                <p>
+                  Interface claire, checklist de tâches et notifications intelligentes pour suivre les échéances sans stress.
+                </p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="indy-tarifs">
+            <h2 id="indy-tarifs">Tarifs et forfaits Indy</h2>
+            <div class="plan-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Formule</th>
+                    <th scope="col">Contenu</th>
+                    <th scope="col">Prix</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Indy Essentiel</th>
+                    <td>Tenue comptable automatisée, TVA, liasses et support chat</td>
+                    <td>49&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Indy Premium</th>
+                    <td>Accompagnement fiscal renforcé, rendez-vous illimités, formation</td>
+                    <td>79&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Option paie</th>
+                    <td>Bulletins de salaire externalisés pour structures avec salariés</td>
+                    <td>25&nbsp;€&nbsp;HT/mois / salarié</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="indy-vigilance">
+            <h2 id="indy-vigilance">Points de vigilance</h2>
+            <p class="lead">
+              Indy excelle pour les entrepreneurs individuels. Pour les sociétés plus structurées, certaines fonctionnalités peuvent
+              nécessiter l'intervention d'un cabinet partenaire.
+            </p>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Sociétés à forte volumétrie</h3>
+                <p>
+                  Les workflows multi-utilisateurs et les exports avancés sont limités. Privilégiez un cabinet hybride si vous traitez
+                  plusieurs milliers d'écritures par mois.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Gestion de la paie</h3>
+                <p>
+                  La production des bulletins est externalisée&nbsp;: anticipez le délai de mise en place et vérifiez les coûts supplémentaires
+                  en cas de croissance de l'effectif.
+                </p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="indy-plan">
+            <h2 id="indy-plan">Plan d'action Indy en 3 étapes</h2>
+            <ol class="timeline timeline-compact" aria-label="Plan d'onboarding Indy">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Activez l'essai guidé</strong>
+                  <p>Inscrivez-vous depuis l'offre Essentiel et programmez une visio découverte pour valider votre cas BNC/BIC.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Connectez vos banques</strong>
+                  <p>Reliez comptes bancaires et outils de facturation afin que l'automatisation catégorise vos opérations.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Planifiez le premier point fiscal</strong>
+                  <p>Bloquez un rendez-vous avec votre conseiller pour valider les déclarations et paramétrer les rappels.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions Indy">
+          <div class="sidebar-card">
+            <h2>Visiter Indy</h2>
+            <p>Profitez de l'offre spéciale indépendants et d'une période d'essai guidée.</p>
+            <a
+              class="button button-primary"
+              href="https://www.indy.fr/?utm_source=comptablepro&amp;utm_medium=fiche"
+              target="_blank"
+              rel="noopener nofollow"
+              >Visiter le site Indy &raquo;</a
+            >
+          </div>
+          <div class="sidebar-card">
+            <h2>En résumé</h2>
+            <ul class="sidebar-list" role="list">
+              <li><strong>Score :</strong> 4,7/5</li>
+              <li><strong>Clients :</strong> BNC, freelances</li>
+              <li><strong>Onboarding :</strong> 7 jours</li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Checklist onboarding</h2>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Importer les relevés bancaires des 12 derniers mois.</li>
+              <li><span class="sidebar-step-index">2</span>Scanner vos justificatifs via l'app mobile.</li>
+              <li><span class="sidebar-step-index">3</span>Configurer les alertes TVA et échéances fiscales.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Besoin d'aide ?</h2>
+            <p>Parlez de votre activité à un expert Comptable Pro pour valider l'adéquation avec Indy.</p>
+            <a class="button button-secondary" href="mailto:contact@example.com">Être rappelé</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/cabinets/keobiz.html
+++ b/cabinets/keobiz.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Keobiz : analyse de l'offre comptable en ligne | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Notre avis sur Keobiz : accompagnement juridique, tarification et points de vigilance pour les créateurs et sociétés en croissance."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="../les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-provider">
+        <div class="content-area">
+          <section class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Keobiz</span>
+            </div>
+            <h1>Keobiz&nbsp;: comptabilité et juridique pour les entrepreneurs ambitieux</h1>
+            <p>
+              Keobiz propose un accompagnement 360° mêlant création d'entreprise, gestion comptable et suivi juridique, idéal pour les
+              dirigeants qui veulent un partenaire unique.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,5/5</span>
+              <span><strong>Clients types</strong> Créateurs, TPE, PME</span>
+              <span><strong>Onboarding</strong> 15 jours ouvrés</span>
+            </div>
+            <ul class="hero-highlights" role="list">
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M5 12l4 4 10-10"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Formalités de création d'entreprise offertes sous conditions
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M12 6v12m6-6H6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Plateforme collaborative pour déposer et suivre les documents en temps réel
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Pôle juridique internalisé pour les assemblées et modifications statutaires
+              </li>
+            </ul>
+          </section>
+
+          <section class="section provider-insights" aria-labelledby="keobiz-insights">
+            <h2 id="keobiz-insights">Points clés Keobiz</h2>
+            <div class="insight-grid">
+              <article class="insight-card">
+                <h3>Session découverte</h3>
+                <p>Organisez un échange pour cartographier vos besoins comptables, juridiques et sociaux.</p>
+                <ul class="insight-list">
+                  <li><span>Délai</span>48&nbsp;h</li>
+                  <li><span>Durée</span>45&nbsp;min</li>
+                  <li><span>Support</span>Visio ou présentiel</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Profil idéal</h3>
+                <ul class="insight-list">
+                  <li><span>Statut</span>SAS / SARL</li>
+                  <li><span>Phase</span>Création ou croissance</li>
+                  <li><span>Besoin</span>Pack 360°</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Document ressource</h3>
+                <p>Téléchargez le guide Keobiz pour structurer votre création d'entreprise pas à pas.</p>
+                <a class="cta-link" href="https://www.keobiz.fr/creation-d-entreprise/" target="_blank" rel="noopener">Télécharger le guide</a>
+              </article>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="keobiz-forces">
+            <h2 id="keobiz-forces">Forces clés de Keobiz</h2>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Accompagnement création</h3>
+                <p>
+                  Conseils sur le statut juridique, rédaction des statuts et immatriculation accélérée grâce au guichet unique Keobiz.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Équipe pluridisciplinaire</h3>
+                <p>
+                  Comptables, fiscalistes et juristes coordonnés pour assurer la conformité et la réactivité sur toutes vos obligations.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Offre modulable</h3>
+                <p>
+                  Possibilité d'ajouter des missions (social, juridique, conseil) à la carte sans changer de prestataire.
+                </p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="keobiz-tarifs">
+            <h2 id="keobiz-tarifs">Tarifs Keobiz</h2>
+            <div class="plan-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Formule</th>
+                    <th scope="col">Contenu</th>
+                    <th scope="col">Prix</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Starter</th>
+                    <td>Tenue comptable, bilan, déclarations fiscales, assistance illimitée</td>
+                    <td>49&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Performance</th>
+                    <td>Conseil fiscal trimestriel, optimisation rémunération dirigeant</td>
+                    <td>89&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Pack juridique</th>
+                    <td>Assemblées générales, modifications statutaires, baux commerciaux</td>
+                    <td>Sur devis</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="keobiz-vigilance">
+            <h2 id="keobiz-vigilance">Points de vigilance</h2>
+            <p class="lead">
+              L'offre Keobiz est dense&nbsp;: vérifiez que les options choisies correspondent à vos besoins pour éviter les surcoûts.
+            </p>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Tarifs modulaires</h3>
+                <p>
+                  Certaines prestations sont facturées à l'acte. Demandez un devis détaillé pour évaluer le coût total de possession.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Suivi projet</h3>
+                <p>
+                  Prévoyez un chef de projet côté client pour coordonner les actions juridiques et comptables simultanées.
+                </p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="keobiz-plan">
+            <h2 id="keobiz-plan">Plan d'action Keobiz</h2>
+            <ol class="timeline timeline-compact" aria-label="Plan d'onboarding Keobiz">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Cadrez votre projet</strong>
+                  <p>Organisez un rendez-vous de cadrage juridique + comptable pour prioriser les missions incluses.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Validez les options</strong>
+                  <p>Choisissez les modules (création, juridique, paie) et faites-vous confirmer les délais associés.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Planifiez le suivi</strong>
+                  <p>Fixez un calendrier de réunions avec votre interlocuteur dédié et partagez votre reporting financier.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions Keobiz">
+          <div class="sidebar-card">
+            <h2>Visiter Keobiz</h2>
+            <p>Accédez aux packs création + comptabilité et obtenez un accompagnement dédié.</p>
+            <a
+              class="button button-primary"
+              href="https://www.keobiz.fr/?utm_source=comptablepro&amp;utm_medium=fiche"
+              target="_blank"
+              rel="noopener nofollow"
+              >Aller sur Keobiz &raquo;</a
+            >
+          </div>
+          <div class="sidebar-card">
+            <h2>En résumé</h2>
+            <ul class="sidebar-list" role="list">
+              <li><strong>Score :</strong> 4,5/5</li>
+              <li><strong>Clients :</strong> Créateurs, TPE</li>
+              <li><strong>Onboarding :</strong> 15 jours</li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Checklist onboarding</h2>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Rassembler statuts, prévisionnel et pièces juridiques.</li>
+              <li><span class="sidebar-step-index">2</span>Signer la lettre de mission et valider les modules optionnels.</li>
+              <li><span class="sidebar-step-index">3</span>Partager votre calendrier d'échéances sociales et fiscales.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Parler à un expert</h2>
+            <p>Vous hésitez entre Keobiz et un cabinet local&nbsp;? Nous vous aidons à comparer les scénarios.</p>
+            <a class="button button-secondary" href="mailto:contact@example.com">Obtenir un avis</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/cabinets/lexpert.html
+++ b/cabinets/lexpert.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>L-expert-comptable.com : fiche cabinet | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Avis et analyse de L-expert-comptable.com : forces, tarifs et recommandations pour choisir ce cabinet en ligne."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="../les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-provider">
+        <div class="content-area">
+          <section class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>L-expert-comptable.com</span>
+            </div>
+            <h1>L-expert-comptable.com&nbsp;: un accompagnement digital et pédagogique</h1>
+            <p>
+              Cabinet pionnier de la comptabilité en ligne, L-expert-comptable.com combine plateforme intuitive, contenus pédagogiques et
+              réseau d'experts pour accompagner les dirigeants de TPE/PME.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,5/5</span>
+              <span><strong>Clients types</strong> TPE, PME, start-up</span>
+              <span><strong>Onboarding</strong> 14 jours ouvrés</span>
+            </div>
+            <ul class="hero-highlights" role="list">
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M5 12l4 4 10-10"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Accès à un centre de ressources complet (guides, webinars, podcasts)
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M12 6v12m6-6H6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Plateforme collaborative pour partager les pièces et suivre les tâches
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Communauté de dirigeants et événements réguliers pour partager les bonnes pratiques
+              </li>
+            </ul>
+          </section>
+
+          <section class="section provider-insights" aria-labelledby="lexpert-insights">
+            <h2 id="lexpert-insights">Points clés L-expert-comptable.com</h2>
+            <div class="insight-grid">
+              <article class="insight-card">
+                <h3>Contact dédié</h3>
+                <p>Programmez un échange avec un expert sectoriel pour cadrer votre périmètre comptable et juridique.</p>
+                <ul class="insight-list">
+                  <li><span>Délai</span>72&nbsp;h</li>
+                  <li><span>Durée</span>45&nbsp;min</li>
+                  <li><span>Format</span>Visio ou physique</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Profil idéal</h3>
+                <ul class="insight-list">
+                  <li><span>Statut</span>SAS / SA / Start-up</li>
+                  <li><span>Équipe</span>Finance structurée</li>
+                  <li><span>Besoin</span>Ressources pédagogiques</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Ressources utiles</h3>
+                <p>Consultez les guides sectoriels pour préparer vos ateliers de cadrage.</p>
+                <a class="cta-link" href="https://www.l-expert-comptable.com/guides" target="_blank" rel="noopener">Voir les guides</a>
+              </article>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="lexpert-forces">
+            <h2 id="lexpert-forces">Forces clés de L-expert-comptable.com</h2>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Plateforme collaborative</h3>
+                <p>Gestion documentaire fluide, rappels automatiques et workflows de validation adaptés aux équipes.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Ressources pédagogiques</h3>
+                <p>Webinars et guides sectoriels pour aider les dirigeants à comprendre les impacts fiscaux et sociaux.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Accompagnement juridique</h3>
+                <p>Assistance aux opérations sur capital, pactes d'associés et missions juridiques récurrentes via le réseau Lexpert.</p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="lexpert-tarifs">
+            <h2 id="lexpert-tarifs">Tarifs L-expert-comptable.com</h2>
+            <div class="plan-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Formule</th>
+                    <th scope="col">Contenu</th>
+                    <th scope="col">Prix</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Essentielle</th>
+                    <td>Tenue comptable, TVA, bilans et accompagnement dédié</td>
+                    <td>À partir de 69&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Croissance</th>
+                    <td>Reporting financier, consolidation et conseil stratégique</td>
+                    <td>Sur devis</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Pack juridique</th>
+                    <td>Assemblées, modifications statutaires, secrétariat juridique</td>
+                    <td>À partir de 39&nbsp;€&nbsp;HT/acte</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="lexpert-vigilance">
+            <h2 id="lexpert-vigilance">Points de vigilance</h2>
+            <p class="lead">
+              L'offre est riche en fonctionnalités. Accompagnez vos équipes pour tirer parti de la plateforme et planifiez les sessions de
+              formation proposées.
+            </p>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Prise en main de la plateforme</h3>
+                <p>Prévoir un temps de formation initial pour les équipes finance afin d'utiliser tous les modules disponibles.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Facturation des actes juridiques</h3>
+                <p>Les actes juridiques sont facturés à la carte. Demandez une projection annuelle pour maîtriser votre budget.</p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="lexpert-plan">
+            <h2 id="lexpert-plan">Plan d'action L-expert-comptable.com</h2>
+            <ol class="timeline timeline-compact" aria-label="Plan d'onboarding L-expert-comptable.com">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Diagnostic stratégique</strong>
+                  <p>Planifiez une visio pour cartographier vos besoins comptables, juridiques et RH avec l'équipe dédiée.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Configuration workspace</strong>
+                  <p>Paramétrez l'espace collaboratif, ajoutez vos collaborateurs et centralisez documents et workflows.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Plan de pilotage</strong>
+                  <p>Définissez vos indicateurs clés et cadences de réunions (mensuelles ou trimestrielles).</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions L-expert-comptable.com">
+          <div class="sidebar-card">
+            <h2>Visiter L-expert-comptable.com</h2>
+            <p>Accédez à la plateforme collaborative et réservez une session de cadrage avec un expert dédié.</p>
+            <a
+              class="button button-primary"
+              href="https://www.l-expert-comptable.com/?utm_source=comptablepro&amp;utm_medium=fiche"
+              target="_blank"
+              rel="noopener nofollow"
+              >Découvrir le site &raquo;</a
+            >
+          </div>
+          <div class="sidebar-card">
+            <h2>En résumé</h2>
+            <ul class="sidebar-list" role="list">
+              <li><strong>Score :</strong> 4,5/5</li>
+              <li><strong>Clients :</strong> TPE, PME</li>
+              <li><strong>Onboarding :</strong> 14 jours</li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Checklist onboarding</h2>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Partager vos derniers bilans et procédures internes.</li>
+              <li><span class="sidebar-step-index">2</span>Inviter vos équipes finance, RH et dirigeants sur l'espace client.</li>
+              <li><span class="sidebar-step-index">3</span>Programmer les ateliers thématiques (RH, fiscal, juridique).</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Échanger avec nous</h2>
+            <p>Besoin de prioriser vos chantiers finance&nbsp;? Nous vous aidons à planifier vos ateliers de cadrage.</p>
+            <a class="button button-secondary" href="mailto:contact@example.com">Parler à un expert</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/cabinets/livli.html
+++ b/cabinets/livli.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Livli : expertise comptable pour e-commerçants | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Nos recommandations sur Livli : intégrations e-commerce, automatisation et accompagnement des marchands en ligne."
+    />
+    <link rel="preload" href="../styles.css" as="style" />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="../index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="../les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="../index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-provider">
+        <div class="content-area">
+          <section class="provider-hero">
+            <div class="breadcrumb">
+              <a href="../index.html">Accueil</a>
+              <span aria-hidden="true">›</span>
+              <a href="../index.html#comparatif">Comparatif</a>
+              <span aria-hidden="true">›</span>
+              <span>Livli</span>
+            </div>
+            <h1>Livli&nbsp;: l'expertise comptable pensée pour l'e-commerce</h1>
+            <p>
+              Livli connecte vos marketplaces et CMS à sa plateforme pour automatiser la récupération des ventes et optimiser votre
+              rentabilité produit par produit.
+            </p>
+            <div class="provider-meta">
+              <span><strong>Score global</strong> 4,6/5</span>
+              <span><strong>Clients types</strong> DNVB, e-commerçants, retail</span>
+              <span><strong>Onboarding</strong> 10 jours ouvrés</span>
+            </div>
+            <ul class="hero-highlights" role="list">
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M5 12l4 4 10-10"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Connecteurs natifs Shopify, Amazon, Prestashop et WooCommerce
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M12 6v12m6-6H6"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Analyses de marge produit et reporting logistique pour piloter vos stocks
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                Équipe dédiée e-commerce avec veille TVA intracommunautaire
+              </li>
+            </ul>
+          </section>
+
+          <section class="section provider-insights" aria-labelledby="livli-insights">
+            <h2 id="livli-insights">Points clés Livli</h2>
+            <div class="insight-grid">
+              <article class="insight-card">
+                <h3>Démo e-commerce</h3>
+                <p>Explorez les connecteurs marketplace avec un expert Livli dédié à vos flux logistiques.</p>
+                <ul class="insight-list">
+                  <li><span>Délai</span>72&nbsp;h</li>
+                  <li><span>Durée</span>45&nbsp;min</li>
+                  <li><span>Format</span>Visio interactive</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Profil idéal</h3>
+                <ul class="insight-list">
+                  <li><span>CA</span>&lt; 8&nbsp;M€</li>
+                  <li><span>Canaux</span>Marketplaces &amp; site propre</li>
+                  <li><span>Objectif</span>Suivi marge produit</li>
+                </ul>
+              </article>
+              <article class="insight-card">
+                <h3>Checklist e-commerce</h3>
+                <p>Préparez vos accès plateformes et flux logistiques pour un onboarding sans friction.</p>
+                <a class="cta-link" href="https://www.livli.fr/ressources/" target="_blank" rel="noopener">Accéder aux ressources</a>
+              </article>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="livli-forces">
+            <h2 id="livli-forces">Forces clés de Livli</h2>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Connecteurs e-commerce</h3>
+                <p>Synchronisation automatique des ventes, remboursements et frais plateformes pour limiter les ressaisies.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Reporting granularité produit</h3>
+                <p>Tableaux de bord dédiés aux marges, coûts logistiques et campagnes marketing pour ajuster vos prix en temps réel.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Veille TVA internationale</h3>
+                <p>Surveillance des seuils OSS/IOSS, gestion des immatriculations et conseil sur la facturation multidevise.</p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="livli-tarifs">
+            <h2 id="livli-tarifs">Tarifs Livli</h2>
+            <div class="plan-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Formule</th>
+                    <th scope="col">Contenu</th>
+                    <th scope="col">Prix</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Comfort</th>
+                    <td>Tenue comptable, déclarations TVA, connecteurs marketplace</td>
+                    <td>79&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Performance</th>
+                    <td>Reporting avancé, conseil fiscal international, pilotage stocks</td>
+                    <td>119&nbsp;€&nbsp;HT/mois</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Option logistique</th>
+                    <td>Analyse coûts transporteurs, optimisation TVA entrepôts UE</td>
+                    <td>Sur devis</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="livli-vigilance">
+            <h2 id="livli-vigilance">Points de vigilance</h2>
+            <p class="lead">
+              Livli est particulièrement adapté aux structures digitales. Pour des activités physiques multi-sites, vérifiez la capacité
+              d'accompagnement local.
+            </p>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Paramétrage initial</h3>
+                <p>Prévoyez un atelier technique pour connecter vos plateformes et aligner vos plans comptables.</p>
+              </li>
+              <li class="highlight-item">
+                <h3>Gestion retail physique</h3>
+                <p>Les processus sont optimisés pour les ventes en ligne. Pour les points de vente physiques, validez les options d'inventaire
+                  et de caisse.</p>
+              </li>
+            </ul>
+          </section>
+
+          <section class="section" aria-labelledby="livli-plan">
+            <h2 id="livli-plan">Plan d'action Livli</h2>
+            <ol class="timeline timeline-compact" aria-label="Plan d'onboarding Livli">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Cartographiez vos flux</strong>
+                  <p>Inventoriez marketplaces, CMS et outils logistiques pour préparer le paramétrage des connecteurs.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Synchronisez les canaux</strong>
+                  <p>Activez les connexions Shopify, Amazon, WooCommerce et vérifiez la remontée des taxes internationales.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Optimisez vos alertes</strong>
+                  <p>Paramétrez les seuils de stock, les marges cibles et les alertes TVA pour piloter en temps réel.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions Livli">
+          <div class="sidebar-card">
+            <h2>Visiter Livli</h2>
+            <p>Connectez vos canaux de vente et profitez d'un paramétrage accompagné par l'équipe Livli.</p>
+            <a
+              class="button button-primary"
+              href="https://www.livli.fr/?utm_source=comptablepro&amp;utm_medium=fiche"
+              target="_blank"
+              rel="noopener nofollow"
+              >Tester Livli &raquo;</a
+            >
+          </div>
+          <div class="sidebar-card">
+            <h2>En résumé</h2>
+            <ul class="sidebar-list" role="list">
+              <li><strong>Score :</strong> 4,6/5</li>
+              <li><strong>Clients :</strong> DNVB, e-commerce</li>
+              <li><strong>Onboarding :</strong> 10 jours</li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Checklist onboarding</h2>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Exporter vos catalogues produits et plans comptables.</li>
+              <li><span class="sidebar-step-index">2</span>Activer les connecteurs marketplace avec un conseiller Livli.</li>
+              <li><span class="sidebar-step-index">3</span>Tester un cycle de commandes pour valider les écritures automatiques.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Besoin d'un diagnostic</h2>
+            <p>Discutons de vos flux marketplace et logistique pour confirmer la compatibilité avec Livli.</p>
+            <a class="button button-secondary" href="mailto:contact@example.com">Échanger avec Comptable Pro</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="../index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="../index.html#faq">FAQ</a></li>
+          <li><a href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,40 +4,37 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Comparatif des cabinets comptables en ligne | Comptable Pro</title>
+    <title>Comptable Pro | Comparatif des cabinets comptables en ligne</title>
     <meta
       name="description"
-      content="Découvrez un comparatif détaillé des cabinets comptables en ligne pour entrepreneurs : tarifs, services et points forts pour indy.fr, Dougs, Livli et plus."
+      content="Trouvez le cabinet comptable en ligne idéal grâce à notre comparatif détaillé, nos analyses et fiches dédiées aux principaux acteurs du marché."
     />
     <meta name="robots" content="index, follow" />
-    <meta name="theme-color" content="#0a4a7c" />
-
+    <meta name="theme-color" content="#ff7aa2" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Comparatif des cabinets comptables en ligne" />
+    <meta property="og:title" content="Comptable Pro | Comparatif des cabinets comptables en ligne" />
     <meta
       property="og:description"
-      content="Choisissez le cabinet comptable en ligne adapté à votre structure grâce à notre analyse professionnelle."
+      content="Analyse indépendante, tableau comparatif et fiches cabinet pour choisir votre expert-comptable en ligne."
     />
     <meta property="og:url" content="https://example.com/" />
     <meta property="og:locale" content="fr_FR" />
     <meta property="og:image" content="https://example.com/assets/images/hero-pattern.svg" />
-    <meta name="twitter:card" content="summary_large_image" />
-
+    <link rel="canonical" href="https://example.com/" />
     <link rel="preload" href="styles.css" as="style" />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="canonical" href="https://example.com/" />
   </head>
   <body>
-    <a href="#content" class="skip-link">Aller au contenu principal</a>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
     <header>
-      <div class="header-inner" role="banner">
-        <nav aria-label="Navigation principale">
-          <a class="brand" href="#">
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="index.html">
             <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255,255,255,0.18)" />
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
               <path
                 d="M16 32l6-14 4 6 6-10"
-                stroke="#ffffff"
+                stroke="#ff7aa2"
                 stroke-width="3"
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -45,307 +42,473 @@
             </svg>
             Comptable Pro
           </a>
-          <ul>
-            <li><a href="#comparatif">Comparatif</a></li>
-            <li><a href="#faq">FAQ</a></li>
-            <li><a href="#contact">Contact</a></li>
-          </ul>
-        </nav>
-        <div class="hero" id="content">
-          <div class="hero-content">
-            <h1>Choisissez le cabinet comptable en ligne qui accélère votre croissance</h1>
-            <p>
-              Nous analysons les acteurs clés du marché pour vous aider à sélectionner la solution qui répond à vos exigences
-              de réactivité, d’accompagnement et de conformité.
-            </p>
-            <div class="hero-cta">
-              <a class="button button-primary" href="#comparatif">Explorer le comparatif</a>
-              <a class="button button-secondary" href="#contact">Obtenir un diagnostic</a>
-            </div>
-          </div>
-          <div class="hero-media">
-            <article class="hero-card" aria-label="Indicateurs clés">
-              <h2>Pourquoi nous faire confiance&nbsp;?</h2>
-              <ul>
-                <li>
-                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                    <path
-                      d="M5 13l4 4L19 7"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  +15 ans d’expertise en digitalisation comptable
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                    <path
-                      d="M12 5v14m7-7H5"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  Analyse indépendante et transparente
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                    <path
-                      d="M3 12l2-2 4 4 10-10"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  Recommandations adaptées à votre structure
-                </li>
-              </ul>
-            </article>
-          </div>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="cabinets/indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="#contact">Contact</a></li>
+            </ul>
+          </nav>
         </div>
       </div>
     </header>
 
-    <main>
-      <section aria-labelledby="section-services">
-        <div class="section-heading">
-          <h2 id="section-services">Un accompagnement stratégique pour les dirigeants</h2>
-          <p>
-            Notre équipe évalue les plateformes comptables selon des critères tangibles : qualité du conseil, profondeur des
-            intégrations logicielles, lisibilité tarifaire et conformité réglementaire.
-          </p>
-        </div>
-        <div class="card-grid" role="list">
-          <article class="card" role="listitem">
-            <h3>Audit personnalisé</h3>
-            <p>
-              Nous passons au crible votre organisation actuelle pour identifier les leviers d’automatisation et de pilotage
-              financier.
+    <main id="contenu">
+      <div class="page layout layout-home">
+        <div class="content-area">
+          <section class="intro-section">
+            <span class="intro-pill">Mise à jour&nbsp;: avril&nbsp;2024</span>
+            <h1>Le comparatif joyeux pour choisir votre cabinet comptable en ligne</h1>
+            <p class="intro-lead">
+              En quelques minutes, identifiez la plateforme qui s'aligne sur votre activité, votre budget et le niveau
+              d'accompagnement humain souhaité. Nous testons chaque service pour garder une approche légère, claire et utile.
             </p>
-          </article>
-          <article class="card" role="listitem">
-            <h3>Mise en place accélérée</h3>
-            <p>
-              Bénéficiez d’un plan d’implémentation sur-mesure pour intégrer rapidement l’outil choisi à vos processus internes.
-            </p>
-          </article>
-          <article class="card" role="listitem">
-            <h3>Suivi et optimisation</h3>
-            <p>
-              Nos experts restent engagés pour mesurer l’adoption, optimiser les routines et sécuriser vos clôtures.
-            </p>
-          </article>
-        </div>
-      </section>
+            <div class="intro-meta">
+              <span class="intro-meta-item">6 cabinets passés au crible</span>
+              <span class="intro-meta-item">24 critères comparés</span>
+              <span class="intro-meta-item">Lecture synthétique en 3&nbsp;minutes</span>
+            </div>
+            <div class="cta-group">
+              <a class="button button-primary" href="#comparatif">Comparer les cabinets</a>
+              <a class="button button-secondary" href="#methodologie">Voir notre méthode</a>
+            </div>
+            <p class="intro-note">Bonus&nbsp;: chaque fiche cabinet propose un plan d'action rapide et des liens d'essai.</p>
+            <div class="intro-highlights" role="list">
+              <article class="intro-highlight" role="listitem">
+                <h3>Comparatif express</h3>
+                <p>
+                  Filtrez les offres en fonction de votre statut (freelance, e-commerce, PME) et accédez à des tarifs à jour.
+                </p>
+              </article>
+              <article class="intro-highlight" role="listitem">
+                <h3>Analyses terrain</h3>
+                <p>
+                  Tests utilisateurs, qualité du support et disponibilité des experts sont vérifiés avant chaque recommandation.
+                </p>
+              </article>
+              <article class="intro-highlight" role="listitem">
+                <h3>Palette positive</h3>
+                <p>
+                  Une ambiance pastel et aérée pour naviguer sereinement entre tableaux, FAQ et plans d'onboarding.
+                </p>
+              </article>
+            </div>
+          </section>
 
-      <section id="comparatif" class="comparison" aria-labelledby="section-comparatif">
-        <div class="section-heading">
-          <h2 id="section-comparatif">Comparatif des cabinets comptables en ligne</h2>
-          <p>Analyse multi-critères des solutions leaders du marché français.</p>
-        </div>
-        <div class="table-wrapper" role="region" aria-labelledby="section-comparatif">
-          <table>
-            <caption class="sr-only">Comparaison des cabinets comptables en ligne</caption>
-            <thead>
-              <tr>
-                <th scope="col">Cabinet</th>
-                <th scope="col">Positionnement</th>
-                <th scope="col">Forces</th>
-                <th scope="col">Points de vigilance</th>
-                <th scope="col">Offre phare</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">indy.fr</th>
-                <td>Solution automatisée pour indépendants et professions libérales.</td>
-                <td>
-                  <strong>Automatisation native</strong>
-                  <span class="badge badge-positive">IA</span>
-                  Import bancaire, déclarations fiscales et TVA en quelques clics.
-                </td>
-                <td>Support plus limité pour les structures sociétaires complexes.</td>
-                <td>Abonnement à partir de 49&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">clementine.fr</th>
-                <td>Cabinet en ligne spécialisé TPE/PME avec pilotage financier.</td>
-                <td>
-                  <strong>Accompagnement humain</strong>
-                  <span class="badge badge-neutral">Conseil</span>
-                  Comptables dédiés et reporting mensuel inclus.
-                </td>
-                <td>Tarifs sur devis, visibilité tarifaire à clarifier.</td>
-                <td>Pack croissance (sur-mesure).</td>
-              </tr>
-              <tr>
-                <th scope="row">Keobiz</th>
-                <td>Cabinet digital pour créateurs et sociétés en croissance.</td>
-                <td>
-                  <strong>Offre juridique intégrée</strong>
-                  <span class="badge badge-positive">360°</span>
-                  Formalités et accompagnement création d’entreprise.
-                </td>
-                <td>Options additionnelles parfois nécessaires pour l’accompagnement premium.</td>
-                <td>Abonnement dès 49&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">Dougs</th>
-                <td>Cabinet 100&nbsp;% en ligne axé automatisation et pédagogie.</td>
-                <td>
-                  <strong>Application mobile</strong>
-                  <span class="badge badge-positive">Temps réel</span>
-                  Tableaux de bord et alertes proactives.
-                </td>
-                <td>Disponibilité des conseillers à planifier sur plages définies.</td>
-                <td>Formule Essentials à 79&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">l-expert-comptable.com</th>
-                <td>Cabinet digital avec forte expertise juridique et fiscale.</td>
-                <td>
-                  <strong>Ressources pédagogiques</strong>
-                  <span class="badge badge-positive">Blog</span>
-                  Webinaires et guides pratiques pour dirigeants.
-                </td>
-                <td>Plateforme parfois dense pour les nouveaux utilisateurs.</td>
-                <td>Pack création + accompagnement comptable.</td>
-              </tr>
-              <tr>
-                <th scope="row">legalplace</th>
-                <td>Plateforme juridique élargie offrant un service comptable.</td>
-                <td>
-                  <strong>Centralisation administrative</strong>
-                  <span class="badge badge-neutral">Plateforme</span>
-                  Formalités juridiques et modèles de documents inclus.
-                </td>
-                <td>Approche comptable moins personnalisée pour la gestion quotidienne.</td>
-                <td>Offre entrepreneurs (tarif modulable).</td>
-              </tr>
-              <tr>
-                <th scope="row">acasi</th>
-                <td>Cabinet en ligne dédié aux freelances et consultants.</td>
-                <td>
-                  <strong>Expérience utilisateur soignée</strong>
-                  <span class="badge badge-positive">UX</span>
-                  Interface intuitive et tutoriels contextualisés.
-                </td>
-                <td>Moins adapté aux sociétés à forte volumétrie comptable.</td>
-                <td>Abonnement mensuel dès 59&nbsp;€&nbsp;HT.</td>
-              </tr>
-              <tr>
-                <th scope="row">socic</th>
-                <td>Cabinet hybride avec bureaux physiques et outils digitaux.</td>
-                <td>
-                  <strong>Proximité régionale</strong>
-                  <span class="badge badge-neutral">Réseau</span>
-                  Experts dédiés par territoire et secteurs spécialisés.
-                </td>
-                <td>Moins de fonctionnalités natives dans l’application en ligne.</td>
-                <td>Contrat sur devis selon le secteur.</td>
-              </tr>
-              <tr>
-                <th scope="row">Wity</th>
-                <td>Offre 360° comptabilité, juridique et conseil stratégique.</td>
-                <td>
-                  <strong>Pilotage financier</strong>
-                  <span class="badge badge-positive">BI</span>
-                  Reporting consolidé et indicateurs personnalisés.
-                </td>
-                <td>Structure tarifaire modulaire à analyser selon vos besoins.</td>
-                <td>Pack Starter TPE/PME.</td>
-              </tr>
-              <tr>
-                <th scope="row">Ça compte pour moi</th>
-                <td>Cabinet 100&nbsp;% en ligne avec service client étendu.</td>
-                <td>
-                  <strong>Disponibilité élargie</strong>
-                  <span class="badge badge-positive">Support</span>
-                  Conseillers joignables du lundi au samedi.
-                </td>
-                <td>Automatisation moins poussée que certains concurrents.</td>
-                <td>Formule sérénité à 69&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-              <tr>
-                <th scope="row">Livli</th>
-                <td>Cabinet en ligne pour entrepreneurs et e-commerçants.</td>
-                <td>
-                  <strong>Intégrations e-commerce</strong>
-                  <span class="badge badge-positive">API</span>
-                  Connexions Shopify, Amazon et marketplace.
-                </td>
-                <td>Accompagnement stratégique en option.</td>
-                <td>Formule Comfort à 79&nbsp;€&nbsp;HT/mois.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
+          <section class="section" id="comparatif" aria-labelledby="titre-comparatif">
+            <h2 id="titre-comparatif">Tableau comparatif 2024 des cabinets comptables en ligne</h2>
+            <p class="lead">
+              Comparez en un coup d'œil le positionnement, les points forts et les forfaits des acteurs sélectionnés. Chaque
+              ligne donne accès à une fiche détaillée avec recommandations, avis clients et un plan d'action en trois étapes.
+            </p>
+            <div class="comparison-table" role="region" aria-labelledby="titre-comparatif">
+              <table>
+                <caption class="sr-only">Comparaison des cabinets comptables en ligne</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Cabinet</th>
+                    <th scope="col">Positionnement</th>
+                    <th scope="col">Atouts majeurs</th>
+                    <th scope="col">Tarifs indicatifs</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Indy</th>
+                    <td>Solution automatisée pour indépendants et professions libérales.</td>
+                    <td>
+                      <strong>Automatisation native</strong>
+                      <span class="badge">IA &amp; Pilotage</span>
+                      Déclarations fiscales et TVA en quelques clics.
+                    </td>
+                    <td>Formule à partir de 49&nbsp;€&nbsp;HT/mois.</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/indy.html">Notre avis sur Indy</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.indy.fr/?utm_source=comptablepro&amp;utm_medium=tableau"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Dougs</th>
+                    <td>Cabinet 100&nbsp;% en ligne axé sur la pédagogie et la mobilité.</td>
+                    <td>
+                      <strong>Application complète</strong>
+                      <span class="badge badge-success">Temps réel</span>
+                      Tableaux de bord, alertes proactives et webinars mensuels.
+                    </td>
+                    <td>Essentiels à 79&nbsp;€&nbsp;HT/mois.</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/dougs.html">Notre avis sur Dougs</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.dougs.fr/?utm_source=comptablepro&amp;utm_medium=tableau"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Keobiz</th>
+                    <td>Accompagnement global pour créateurs et sociétés en croissance.</td>
+                    <td>
+                      <strong>Offre juridique intégrée</strong>
+                      <span class="badge badge-neutral">360°</span>
+                      Formalités et missions juridiques incluses.
+                    </td>
+                    <td>Abonnement dès 49&nbsp;€&nbsp;HT/mois.</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/keobiz.html">Notre avis sur Keobiz</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.keobiz.fr/?utm_source=comptablepro&amp;utm_medium=tableau"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">L-expert-comptable.com</th>
+                    <td>Cabinet digital historique avec forte expertise juridique.</td>
+                    <td>
+                      <strong>Ressources pédagogiques</strong>
+                      <span class="badge">Communauté</span>
+                      Webinaires, guides pratiques et club dirigeant.
+                    </td>
+                    <td>Forfaits sur-mesure à partir de 69&nbsp;€&nbsp;HT/mois.</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/lexpert.html">Notre avis sur L-expert-comptable.com</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.l-expert-comptable.com/?utm_source=comptablepro&amp;utm_medium=tableau"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Livli</th>
+                    <td>Spécialiste e-commerce et activités digitales.</td>
+                    <td>
+                      <strong>Intégrations API</strong>
+                      <span class="badge badge-success">E-commerce</span>
+                      Connexions Shopify, Amazon et marketplace.
+                    </td>
+                    <td>Formule Comfort à 79&nbsp;€&nbsp;HT/mois.</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/livli.html">Notre avis sur Livli</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.livli.fr/?utm_source=comptablepro&amp;utm_medium=tableau"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Clémentine</th>
+                    <td>Pilotage financier premium pour TPE/PME en croissance.</td>
+                    <td>
+                      <strong>Reporting actionnable</strong>
+                      <span class="badge badge-neutral">Conseil</span>
+                      Contrôleur de gestion et réunions trimestrielles.
+                    </td>
+                    <td>Pack croissance sur devis personnalisé.</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/clementine.html">Notre avis sur Clémentine</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.clementine.pro/?utm_source=comptablepro&amp;utm_medium=tableau"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="review-snippet">
+              <blockquote>
+                «&nbsp;Grâce au comparatif Comptable Pro, nous avons identifié le cabinet capable d'automatiser nos flux Shopify
+                et d'anticiper nos besoins de trésorerie. L'onboarding a été bouclé en deux semaines.&nbsp;»
+              </blockquote>
+              <cite>— Sarah M., fondatrice d'une DNVB</cite>
+            </div>
+          </section>
 
-      <section class="faq" id="faq" aria-labelledby="section-faq">
-        <div class="section-heading">
-          <h2 id="section-faq">Questions fréquentes</h2>
-          <p>Clarifiez vos interrogations avant de sélectionner votre cabinet.</p>
-        </div>
-        <div class="faq-list" role="list">
-          <article class="faq-item" role="listitem">
-            <h3>Quel est le délai moyen d’onboarding&nbsp;?</h3>
-            <p>
-              Les plateformes entièrement digitalisées permettent une mise en route en 7 à 15 jours selon la migration de vos
-              écritures et la complexité de votre activité.
+          <section class="section usecase-section" id="cas-clients" aria-labelledby="titre-cas">
+            <h2 id="titre-cas">Trois cas clients pour vous guider</h2>
+            <p class="lead">
+              Nos recommandations varient selon la maturité de votre projet. Voici trois scénarios réels pour vous projeter
+              rapidement vers le bon cabinet.
             </p>
-          </article>
-          <article class="faq-item" role="listitem">
-            <h3>Comment comparer les offres tarifaires&nbsp;?</h3>
-            <p>
-              Analysez le périmètre inclus (déclarations fiscales, bilan, paie, juridique) et identifiez les coûts additionnels
-              pour les prestations ponctuelles (assemblées, commissariat, conseil social).
-            </p>
-          </article>
-          <article class="faq-item" role="listitem">
-            <h3>Quelle importance pour l’accompagnement humain&nbsp;?</h3>
-            <p>
-              Même avec une forte automatisation, privilégiez un interlocuteur dédié capable de vous alerter sur les impacts
-              fiscaux et d’adapter les paramétrages aux évolutions réglementaires.
-            </p>
-          </article>
-        </div>
-      </section>
+            <div class="usecase-grid">
+              <article class="usecase-card">
+                <h3>Freelance en croissance</h3>
+                <p>Vous facturez seul et souhaitez automatiser 90&nbsp;% de votre administratif.</p>
+                <ul>
+                  <li>Indy ou Dougs pour sécuriser TVA et déclarations 2035.</li>
+                  <li>Connectez vos comptes bancaires et plateformes de facturation.</li>
+                  <li>Planifiez un point trimestriel avec un conseiller fiscal.</li>
+                </ul>
+              </article>
+              <article class="usecase-card">
+                <h3>Boutique e-commerce</h3>
+                <p>Vous gérez plusieurs marketplaces et avez besoin d'un suivi stock/TVA multi-pays.</p>
+                <ul>
+                  <li>Livli pour ses connecteurs Shopify, Amazon et WooCommerce.</li>
+                  <li>Dashboard temps réel pour suivre marge et trésorerie.</li>
+                  <li>Option paie ou juridique activable à la demande.</li>
+                </ul>
+              </article>
+              <article class="usecase-card">
+                <h3>TPE en structuration</h3>
+                <p>Vous recrutez, le juridique se complexifie et vous voulez un copilote financier.</p>
+                <ul>
+                  <li>Clémentine ou Keobiz pour le combo compta + juridique.</li>
+                  <li>Reporting personnalisé et réunions de pilotage.</li>
+                  <li>Accompagnement au changement pour votre équipe interne.</li>
+                </ul>
+              </article>
+            </div>
+          </section>
 
-      <section class="cta" id="contact" aria-labelledby="section-cta">
-        <div class="section-heading">
-          <h2 id="section-cta">Prêt à accélérer votre pilotage financier&nbsp;?</h2>
-          <p>
-            Réservez une session de diagnostic offerte avec un expert Comptable Pro pour aligner vos objectifs business et votre
-            organisation comptable.
-          </p>
-          <a class="button button-primary" href="mailto:contact@example.com">Planifier un échange</a>
+          <section class="section" id="methodologie" aria-labelledby="titre-methodologie">
+            <h2 id="titre-methodologie">Comment nous sélectionnons les cabinets mis en avant</h2>
+            <p class="lead">
+              Chaque trimestre, nous analysons 24 critères regroupant l'accompagnement humain, la technologie proposée et la
+              transparence tarifaire. Nos recommandations varient selon votre statut, votre secteur et vos ambitions de
+              croissance.
+            </p>
+            <div class="features-grid">
+              <article class="feature-card">
+                <h3>Accompagnement humain</h3>
+                <p>
+                  Interlocuteur dédié, disponibilité de l'équipe, qualité du conseil stratégique et pédagogie sur vos
+                  obligations quotidiennes.
+                </p>
+              </article>
+              <article class="feature-card">
+                <h3>Plateforme &amp; automatisation</h3>
+                <p>
+                  Synchronisation bancaire, intégrations e-commerce, tableaux de bord temps réel et connecteurs API pour
+                  automatiser les tâches répétitives.
+                </p>
+              </article>
+              <article class="feature-card">
+                <h3>Lisibilité tarifaire</h3>
+                <p>
+                  Transparence des forfaits, coût des missions complémentaires et inclusion des volets juridiques ou sociaux.
+                </p>
+              </article>
+            </div>
+            <div class="stat-grid">
+              <div class="stat">
+                <strong>92&nbsp;%</strong>
+                des dirigeants accompagnés améliorent leur pilotage de trésorerie en moins de 6&nbsp;mois.
+              </div>
+              <div class="stat">
+                <strong>35&nbsp;h</strong>
+                gagnées chaque année grâce à l'automatisation des écritures et relances.
+              </div>
+              <div class="stat">
+                <strong>0</strong>
+                retard constaté sur les obligations fiscales depuis 2022.
+              </div>
+            </div>
+            <h3 class="section-subheading">Notre processus de notation en 4 étapes</h3>
+            <ol class="timeline" aria-label="Processus d'analyse Comptable Pro">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Audit fonctionnel</strong>
+                  <p>Tests en situation réelle des applications web et mobiles, vérification des connecteurs et des limites.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Entretiens experts</strong>
+                  <p>Visios avec les équipes comptables, juridiques et support pour comprendre leur organisation.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Analyse tarifaire</strong>
+                  <p>Décryptage des forfaits, options et coûts cachés pour établir un coût total de possession réaliste.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">4</span>
+                <div>
+                  <strong>Retours utilisateurs</strong>
+                  <p>Collecte d'avis clients vérifiés et retours d'onboarding pour ajuster notre recommandation finale.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+
+          <section class="section" id="faq" aria-labelledby="titre-faq">
+            <h2 id="titre-faq">Questions fréquentes</h2>
+            <div class="faq-list">
+              <article class="faq-item">
+                <h3>Combien de temps pour basculer vers un cabinet en ligne&nbsp;?</h3>
+                <p>
+                  Les cabinets digitalisés finalisent l'onboarding entre 10 et 20 jours ouvrés selon la récupération des pièces
+                  et la reprise de la comptabilité historique.
+                </p>
+              </article>
+              <article class="faq-item">
+                <h3>Peut-on conserver un interlocuteur dédié&nbsp;?</h3>
+                <p>
+                  Oui. Tous les cabinets comparés proposent au minimum un expert-comptable référent. Nous vérifions les plages
+                  de disponibilité, les SLA de réponse et la présence de réunions de pilotage.
+                </p>
+              </article>
+              <article class="faq-item">
+                <h3>Comment sont calculés vos scores&nbsp;?</h3>
+                <p>
+                  Notre grille agrège les avis vérifiés, les fonctionnalités natives, le coût total de possession et les retours
+                  de nos clients accompagnés. Chaque cabinet est re-noté à chaque mise à jour majeure.
+                </p>
+              </article>
+              <article class="faq-item">
+                <h3>À quelle fréquence mettez-vous le comparatif à jour&nbsp;?</h3>
+                <p>
+                  Nous publions une actualisation complète chaque trimestre et effectuons des mises à jour flash dès qu'un
+                  cabinet modifie ses tarifs ou ses fonctionnalités clés.
+                </p>
+              </article>
+              <article class="faq-item">
+                <h3>Puis-je changer de cabinet facilement&nbsp;?</h3>
+                <p>
+                  Oui, la plupart des acteurs prennent en charge la migration des pièces comptables. Pensez à anticiper le délai
+                  de résiliation de votre cabinet actuel pour éviter une double facturation.
+                </p>
+              </article>
+            </div>
+          </section>
+
+          <section class="section cta-banner" id="contact" aria-labelledby="titre-contact">
+            <h2 id="titre-contact">Besoin d'un diagnostic personnalisé&nbsp;?</h2>
+            <p>
+              Décrivez votre activité, votre volumétrie et vos attentes. Nous vous rappelons sous 72&nbsp;heures avec une
+              shortlist de cabinets adaptés et un plan de migration.
+            </p>
+            <a class="button button-primary" href="mailto:contact@example.com">Écrire à un expert Comptable Pro</a>
+          </section>
         </div>
-      </section>
+
+        <aside class="sidebar" aria-label="Accès rapide">
+          <div class="sidebar-card">
+            <h2>Checklist express</h2>
+            <p>Trois étapes pour identifier rapidement le cabinet qui vous correspond.</p>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Choisissez votre statut : freelance, société ou e-commerce.</li>
+              <li><span class="sidebar-step-index">2</span>Comparez les offres via le tableau principal.</li>
+              <li><span class="sidebar-step-index">3</span>Ouvrez la fiche dédiée pour le plan d'onboarding détaillé.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Cabinets favoris 2024</h2>
+            <ol class="sidebar-list">
+              <li><a href="cabinets/indy.html">Indy — automatisation</a></li>
+              <li><a href="cabinets/dougs.html">Dougs — pédagogie</a></li>
+              <li><a href="cabinets/keobiz.html">Keobiz — offre 360°</a></li>
+              <li><a href="cabinets/lexpert.html">L-expert-comptable.com</a></li>
+              <li><a href="cabinets/livli.html">Livli — e-commerce</a></li>
+              <li><a href="cabinets/clementine.html">Clémentine — pilotage</a></li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Guides populaires</h2>
+            <ul class="sidebar-list" role="list">
+              <li><a href="#cas-clients">Cas clients à découvrir</a></li>
+              <li><a href="les-moins-chers.html">Classement des moins chers</a></li>
+              <li><a href="#faq">Questions fréquentes</a></li>
+            </ul>
+            <a class="button button-secondary" href="#contact">Parler à un expert</a>
+          </div>
+        </aside>
+      </div>
     </main>
 
     <footer>
       <div class="footer-inner">
-        <p>&copy; <span id="year">2024</span> Comptable Pro. Tous droits réservés.</p>
-        <nav aria-label="Navigation pied de page">
-          <ul>
-            <li><a href="#">Mentions légales</a></li>
-            <li><a href="#">Politique de confidentialité</a></li>
-            <li><a href="#">Préférences cookies</a></li>
-          </ul>
-        </nav>
+        <p>&copy; <span id="annee">2024</span> Comptable Pro. Comparatif indépendant des cabinets comptables en ligne.</p>
+        <ul>
+          <li><a href="#">Mentions légales</a></li>
+          <li><a href="#">Politique de confidentialité</a></li>
+          <li><a href="#">Paramètres cookies</a></li>
+        </ul>
       </div>
     </footer>
     <script>
-      const year = new Date().getFullYear();
-      const yearHolder = document.getElementById("year");
-      if (yearHolder) {
-        yearHolder.textContent = year;
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
       }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
     </script>
   </body>
 </html>

--- a/les-moins-chers.html
+++ b/les-moins-chers.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cabinets comptables en ligne : les moins chers | Comptable Pro</title>
+    <meta
+      name="description"
+      content="Découvrez le classement des cabinets comptables en ligne par prix décroissant, comparez leurs offres d'entrée et accédez à nos analyses détaillées."
+    />
+    <link rel="preload" href="styles.css" as="style" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <a href="#contenu" class="skip-link">Aller au contenu</a>
+    <header>
+      <div class="header-inner">
+        <div class="header-top">
+          <a class="brand" href="index.html">
+            <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <rect x="2" y="2" width="44" height="44" rx="12" fill="rgba(255, 122, 162, 0.22)" />
+              <path
+                d="M16 32l6-14 4 6 6-10"
+                stroke="#ff7aa2"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Comptable Pro
+          </a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu-principal">Menu</button>
+          <nav id="menu-principal" class="site-nav" aria-label="Navigation principale">
+            <ul>
+              <li class="menu-item has-submenu">
+                <button class="submenu-toggle" type="button" aria-expanded="false">Meilleurs comptables</button>
+                <ul class="submenu" role="menu">
+                  <li role="none"><a role="menuitem" href="cabinets/indy.html">Indy</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/dougs.html">Dougs</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/keobiz.html">Keobiz</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/lexpert.html">L-expert-comptable.com</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/livli.html">Livli</a></li>
+                  <li role="none"><a role="menuitem" href="cabinets/clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
+              <li class="menu-item"><a href="les-moins-chers.html">Les moins chers</a></li>
+              <li class="menu-item"><a href="index.html#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="contenu">
+      <div class="page layout layout-pricing">
+        <div class="content-area">
+          <section class="intro-section">
+            <span class="intro-pill">Classement budgets&nbsp;2024</span>
+            <h1>Les cabinets comptables en ligne les plus abordables</h1>
+            <p class="intro-lead">
+              Visualisez immédiatement les formules d'entrée classées par prix décroissant et comprenez ce qui est inclus pour
+              éviter les mauvaises surprises. Nous vérifions les frais annexes, les promotions et les options incontournables.
+            </p>
+            <div class="intro-meta">
+              <span class="intro-meta-item">6 offres passées au scanner</span>
+              <span class="intro-meta-item">Tarifs vérifiés en avril&nbsp;2024</span>
+              <span class="intro-meta-item">Checklist négociation incluse</span>
+            </div>
+            <div class="cta-group">
+              <a class="button button-primary" href="#classement">Voir le classement détaillé</a>
+              <a class="button button-secondary" href="index.html#comparatif">Retourner au comparatif complet</a>
+            </div>
+            <p class="intro-note">Astuce&nbsp;: comparez toujours les missions incluses avant de valider une remise.</p>
+          </section>
+
+          <section class="section" id="classement" aria-labelledby="titre-prix">
+            <h2 id="titre-prix">Classement par prix décroissant des offres d'entrée</h2>
+            <p class="lead">
+              Les prix affichés correspondent au premier palier récurrent (hors promotions temporaires). Pensez à vérifier les
+              options complémentaires comme la paie, le juridique ou les intégrations spécifiques.
+            </p>
+            <div class="comparison-table" role="region" aria-labelledby="titre-prix">
+              <table>
+                <caption class="sr-only">Classement des cabinets comptables en ligne par prix décroissant</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Cabinet</th>
+                    <th scope="col">Formule d'entrée</th>
+                    <th scope="col">Prix indicatif</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Clémentine</th>
+                    <td>Pack Croissance avec réunions de pilotage trimestrielles</td>
+                    <td>À partir de 249&nbsp;€&nbsp;HT/mois</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/clementine.html">Notre avis sur Clémentine</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.clementine.pro/?utm_source=comptablepro&amp;utm_medium=tableau-prix"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Dougs</th>
+                    <td>Formule Essentiel (tenue + bilans + application)</td>
+                    <td>79&nbsp;€&nbsp;HT/mois</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/dougs.html">Notre avis sur Dougs</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.dougs.fr/?utm_source=comptablepro&amp;utm_medium=tableau-prix"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Livli</th>
+                    <td>Formule Comfort dédiée aux e-commerçants</td>
+                    <td>79&nbsp;€&nbsp;HT/mois</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/livli.html">Notre avis sur Livli</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.livli.fr/?utm_source=comptablepro&amp;utm_medium=tableau-prix"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">L-expert-comptable.com</th>
+                    <td>Formule Essentielle pour TPE/PME</td>
+                    <td>69&nbsp;€&nbsp;HT/mois</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/lexpert.html">Notre avis sur L-expert-comptable.com</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.l-expert-comptable.com/?utm_source=comptablepro&amp;utm_medium=tableau-prix"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Indy</th>
+                    <td>Indy Essentiel pour indépendants</td>
+                    <td>49&nbsp;€&nbsp;HT/mois</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/indy.html">Notre avis sur Indy</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.indy.fr/?utm_source=comptablepro&amp;utm_medium=tableau-prix"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Keobiz</th>
+                    <td>Formule Starter (créateurs et TPE)</td>
+                    <td>49&nbsp;€&nbsp;HT/mois</td>
+                    <td>
+                      <div class="table-actions">
+                        <a class="button button-secondary" href="cabinets/keobiz.html">Notre avis sur Keobiz</a>
+                        <a
+                          class="button button-ghost"
+                          href="https://www.keobiz.fr/?utm_source=comptablepro&amp;utm_medium=tableau-prix"
+                          target="_blank"
+                          rel="noopener nofollow"
+                          >Visiter le site &raquo;</a
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="titre-conseils">
+            <h2 id="titre-conseils">Nos conseils pour rester dans votre budget</h2>
+            <div class="budget-callout">
+              <h3>Mini-checklist avant de signer</h3>
+              <p>Quelques questions à poser pour verrouiller votre enveloppe annuelle.</p>
+              <ul>
+                <li>Quel est le prix après la première année ou la promotion en cours&nbsp;?</li>
+                <li>Quelles missions sont incluses (bilan, TVA, paie, juridique) et lesquelles sont en option&nbsp;?</li>
+                <li>Existe-t-il des frais de migration ou de résiliation anticipée&nbsp;?</li>
+              </ul>
+            </div>
+            <ul class="highlight-list">
+              <li class="highlight-item">
+                <h3>Identifiez vos missions essentielles</h3>
+                <p>
+                  Listez les tâches obligatoires (déclarations, bilans, paie) et celles optionnelles pour déterminer si un forfait
+                  d'entrée suffit ou si un accompagnement premium est nécessaire.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Comparez le coût total de possession</h3>
+                <p>
+                  Vérifiez les frais cachés (lettres de mission additionnelles, intégrations payantes, assistance juridique) pour
+                  éviter les surprises en cours d'année.
+                </p>
+              </li>
+              <li class="highlight-item">
+                <h3>Négociez les paliers de croissance</h3>
+                <p>
+                  Anticipez vos recrutements et l'évolution de votre chiffre d'affaires pour sécuriser les tarifs et prévoir les
+                  options nécessaires.
+                </p>
+              </li>
+            </ul>
+            <h3 class="section-subheading">Plan de négociation en 3 étapes</h3>
+            <ol class="timeline timeline-compact" aria-label="Plan de négociation budget">
+              <li>
+                <span class="timeline-step">1</span>
+                <div>
+                  <strong>Préparez vos chiffres</strong>
+                  <p>Volume de pièces, chiffre d'affaires et besoins en paie pour cadrer l'offre avec des données concrètes.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">2</span>
+                <div>
+                  <strong>Challengez les options</strong>
+                  <p>Demandez ce qui est compris dans le forfait et négociez les remises sur les modules additionnels.</p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline-step">3</span>
+                <div>
+                  <strong>Sécurisez la sortie</strong>
+                  <p>Ajoutez une clause de résiliation souple et vérifiez la récupération gratuite de vos données.</p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar" aria-label="Actions budget">
+          <div class="sidebar-card">
+            <h2>Checklist budget</h2>
+            <p>Suivez ces trois étapes pour sécuriser votre offre la moins chère.</p>
+            <ol class="sidebar-steps">
+              <li><span class="sidebar-step-index">1</span>Comparez au moins deux devis pour obtenir une remise.</li>
+              <li><span class="sidebar-step-index">2</span>Validez noir sur blanc les missions incluses.</li>
+              <li><span class="sidebar-step-index">3</span>Planifiez un point à 6 mois pour ajuster le forfait.</li>
+            </ol>
+          </div>
+          <div class="sidebar-card">
+            <h2>Top économies</h2>
+            <ul class="sidebar-list" role="list">
+              <li><a href="cabinets/indy.html">Indy - Offre Essentiel</a></li>
+              <li><a href="cabinets/keobiz.html">Keobiz - Starter</a></li>
+              <li><a href="cabinets/dougs.html">Dougs - Essentiel</a></li>
+            </ul>
+          </div>
+          <div class="sidebar-card">
+            <h2>Passer à l'action</h2>
+            <p>Expliquez-nous vos besoins et recevez une shortlist adaptée à votre budget en 72&nbsp;h.</p>
+            <a class="button button-primary" href="mailto:contact@example.com">Contacter un expert</a>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="annee">2024</span> Comptable Pro.</p>
+        <ul>
+          <li><a href="index.html#comparatif">Retour au comparatif</a></li>
+          <li><a href="index.html#faq">FAQ</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </footer>
+    <script>
+      const annee = document.getElementById("annee");
+      if (annee) {
+        annee.textContent = new Date().getFullYear();
+      }
+
+      const navToggle = document.querySelector(".nav-toggle");
+      const siteNav = document.querySelector(".site-nav");
+      if (navToggle && siteNav) {
+        navToggle.addEventListener("click", () => {
+          const isExpanded = navToggle.getAttribute("aria-expanded") === "true";
+          navToggle.setAttribute("aria-expanded", String(!isExpanded));
+          siteNav.classList.toggle("is-open", !isExpanded);
+        });
+
+        siteNav.querySelectorAll("a").forEach((link) => {
+          link.addEventListener("click", () => {
+            if (window.innerWidth < 960 && siteNav.classList.contains("is-open")) {
+              siteNav.classList.remove("is-open");
+              navToggle.setAttribute("aria-expanded", "false");
+            }
+          });
+        });
+      }
+
+      document.querySelectorAll(".submenu-toggle").forEach((button) => {
+        button.addEventListener("click", () => {
+          const isExpanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!isExpanded));
+          button.parentElement?.classList.toggle("is-open", !isExpanded);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,20 @@
 :root {
-  --color-primary: #0a4a7c;
-  --color-secondary: #2f3c48;
-  --color-accent: #0d6efd;
-  --color-background: #f5f7fa;
+  --color-primary: #ff7aa2;
+  --color-primary-dark: #f45b89;
+  --color-blue: #3a6ed9;
+  --color-blue-soft: #edf3ff;
+  --color-rose-soft: #fff6fb;
   --color-surface: #ffffff;
-  --color-text: #1a1f24;
-  --color-muted: #6c7a89;
-  --max-width: 1120px;
+  --color-muted: #4a3f58;
+  --color-mint: #d6f4ef;
+  --color-lilac: #f1edff;
+  --color-peach-soft: #ffe9f2;
+  --color-border: rgba(58, 110, 217, 0.12);
+  --font-sans: "Inter", "Segoe UI", sans-serif;
+  --radius-lg: 24px;
   --radius: 16px;
-  --shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+  --shadow-soft: 0 24px 45px rgba(58, 110, 217, 0.08);
+  --max-width: 1180px;
 }
 
 * {
@@ -22,24 +28,25 @@ html {
 
 body {
   margin: 0;
-  font-family: "Inter", "Segoe UI", sans-serif;
-  color: var(--color-text);
-  background: var(--color-background);
+  font-family: var(--font-sans);
+  color: #2b2740;
+  background: #ffffff;
   line-height: 1.6;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
 a:hover,
 a:focus {
-  color: var(--color-accent);
+  color: var(--color-blue);
 }
 
 img {
-  max-width: 100%;
   display: block;
+  max-width: 100%;
   height: auto;
 }
 
@@ -51,33 +58,47 @@ img {
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
   border: 0;
 }
 
-header {
-  background: linear-gradient(135deg, rgba(10, 74, 124, 0.95), rgba(47, 60, 72, 0.95)), url("assets/images/hero-pattern.svg"), #0a4a7c;
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-blue);
   color: #fff;
-  padding: 3.5rem 1.5rem 4.5rem;
+  border-radius: 999px;
+  z-index: 999;
+  transition: top 0.2s ease;
 }
 
-.header-inner,
-main > section,
-footer .footer-inner {
+.skip-link:focus {
+  top: 1rem;
+}
+
+header {
+  background: #ffffff;
+  color: #1f2432;
+  padding: 1.75rem 1.5rem 2rem;
+  border-bottom: 1px solid rgba(58, 110, 217, 0.08);
+}
+
+.header-inner {
   max-width: var(--max-width);
   margin: 0 auto;
 }
 
-nav {
+.header-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  margin-bottom: 3rem;
+  position: relative;
 }
 
 .brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.75rem;
   font-weight: 700;
@@ -86,74 +107,384 @@ nav {
 }
 
 .brand svg {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
 }
 
-nav ul {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
+.nav-toggle {
+  display: none;
+  border: 1px solid rgba(58, 110, 217, 0.25);
+  background: transparent;
+  color: #1f2432;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.site-nav {
+  position: relative;
+}
+
+.site-nav ul {
   margin: 0;
   padding: 0;
+  display: flex;
+  align-items: center;
+  list-style: none;
+  gap: 1rem;
 }
 
-nav a {
-  text-decoration: none;
+.site-nav a,
+.site-nav button {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
-  padding: 0.5rem 0.75rem;
+  color: rgba(31, 36, 50, 0.78);
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
 }
 
-nav a:focus,
-nav a:hover {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.12);
+.submenu-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.submenu-toggle::after {
+  content: "▾";
+  font-size: 0.75rem;
+}
+
+.site-nav a:hover,
+.site-nav a:focus,
+.site-nav button:hover,
+.site-nav button:focus {
+  color: #1f2432;
+  background: var(--color-blue-soft);
+}
+
+.menu-item {
+  position: relative;
+}
+
+.submenu {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  left: 0;
+  min-width: 240px;
+  background: #ffffff;
+  border-radius: var(--radius);
+  box-shadow: 0 18px 36px rgba(31, 36, 50, 0.12);
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  padding: 0.75rem 0;
+  list-style: none;
+  display: none;
+  z-index: 10;
+}
+
+.menu-item.is-open > .submenu,
+.menu-item:hover > .submenu,
+.menu-item:focus-within > .submenu {
+  display: block;
+}
+
+.submenu li a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: #1f2432;
+  border-radius: 0;
+}
+
+.submenu li a:hover,
+.submenu li a:focus {
+  background: var(--color-rose-soft);
 }
 
 .hero {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
+  gap: 2.5rem;
+  align-items: start;
+  margin-top: 3rem;
+}
+
+.hero-home {
+  border-radius: var(--radius-lg);
+  padding: 2.75rem;
+  background: linear-gradient(135deg, var(--color-rose-soft), #ffffff 55%, var(--color-blue-soft));
+  box-shadow: var(--shadow-soft);
+}
+
+.intro-section {
+  background: linear-gradient(140deg, #ffffff, var(--color-rose-soft) 45%, var(--color-mint));
+  border-radius: var(--radius-lg);
+  padding: 2.75rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.6rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  position: relative;
+  overflow: hidden;
+}
+
+.intro-section::after {
+  content: "";
+  position: absolute;
+  inset: auto -80px -120px auto;
+  width: 260px;
+  height: 260px;
+  background: radial-gradient(circle at center, rgba(58, 110, 217, 0.18), transparent 70%);
+  pointer-events: none;
+}
+
+.intro-pill {
+  display: inline-flex;
   align-items: center;
+  gap: 0.4rem;
+  background: rgba(58, 110, 217, 0.12);
+  color: var(--color-blue);
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.92rem;
+  letter-spacing: 0.02em;
+  width: fit-content;
 }
 
-.hero-content h1 {
-  font-size: clamp(2.3rem, 3vw + 1.5rem, 3.5rem);
-  margin-bottom: 1rem;
-  line-height: 1.1;
+.intro-lead {
+  font-size: 1.1rem;
+  color: rgba(31, 36, 50, 0.78);
+  max-width: 60ch;
 }
 
-.hero-content p {
-  font-size: 1.125rem;
-  color: rgba(255, 255, 255, 0.86);
-  margin-bottom: 1.75rem;
+.intro-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
 }
 
-.hero-cta {
+.intro-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(255, 122, 162, 0.18);
+  color: var(--color-primary-dark);
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.cta-group {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+}
+
+.intro-note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(31, 36, 50, 0.6);
+}
+
+.intro-highlights {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  position: relative;
+  z-index: 1;
+}
+
+.intro-highlight {
+  background: #ffffff;
+  border-radius: var(--radius);
+  padding: 1.25rem 1.4rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  box-shadow: 0 16px 32px rgba(58, 110, 217, 0.08);
+  display: grid;
+  gap: 0.55rem;
+}
+
+.intro-highlight h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--color-blue);
+}
+
+.intro-highlight p {
+  margin: 0;
+  font-size: 0.98rem;
+  color: rgba(31, 36, 50, 0.72);
+}
+
+.hero-copy h1 {
+  margin: 0 0 1.2rem;
+  font-size: clamp(2.5rem, 4vw + 1rem, 3.6rem);
+  line-height: 1.05;
+}
+
+.hero-copy p {
+  margin-bottom: 1.5rem;
+  color: rgba(31, 36, 50, 0.75);
+  font-size: 1.15rem;
+  max-width: 48ch;
+}
+
+.usecase-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.usecase-card {
+  background: linear-gradient(135deg, var(--color-blue-soft), #ffffff 60%, var(--color-lilac));
+  border-radius: var(--radius-lg);
+  padding: 2.1rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  box-shadow: 0 20px 38px rgba(58, 110, 217, 0.08);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.usecase-card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.usecase-card p {
+  margin: 0;
+  color: rgba(31, 36, 50, 0.7);
+}
+
+.usecase-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.usecase-card li {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  font-weight: 500;
+  color: #2b2740;
+}
+
+.usecase-card li::before {
+  content: "✦";
+  color: var(--color-primary);
+  font-size: 0.9rem;
+  margin-top: 0.15rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-points {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-points li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  color: #1f2432;
+}
+
+.hero-card {
+  background: #ffffff;
+  border-radius: var(--radius);
+  padding: 2rem;
+  border: 1px solid rgba(58, 110, 217, 0.1);
+  box-shadow: 0 18px 28px rgba(31, 36, 50, 0.06);
+}
+
+.hero-card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.6rem;
+}
+
+.hero-card p {
+  color: rgba(31, 36, 50, 0.7);
+}
+
+.hero-card ul {
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  color: rgba(31, 36, 50, 0.85);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: var(--color-blue);
+}
+
+.hero-highlights {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+  list-style: none;
+  padding: 0;
+}
+
+.hero-highlights li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.95rem 1.1rem;
+  background: var(--color-blue-soft);
+  border-radius: var(--radius);
+  border: 1px solid rgba(58, 110, 217, 0.15);
+  color: #1f2432;
+}
+
+.hero-highlights svg {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  color: var(--color-blue);
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.85rem 1.6rem;
-  border-radius: 999px;
   font-weight: 600;
-  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.6rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  border: none;
+  cursor: pointer;
 }
 
 .button-primary {
-  background: #fff;
-  color: var(--color-primary);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 16px 35px rgba(255, 122, 162, 0.28);
 }
 
 .button-primary:hover,
@@ -162,139 +493,200 @@ nav a:hover {
 }
 
 .button-secondary {
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  color: #fff;
+  background: #ffffff;
+  color: var(--color-blue);
+  border: 2px solid rgba(58, 110, 217, 0.22);
+  box-shadow: none;
 }
 
-.hero-media {
-  position: relative;
-  isolation: isolate;
+.button-ghost {
+  background: transparent;
+  color: var(--color-blue);
+  padding: 0.65rem 1.1rem;
 }
 
-.hero-card {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(12px);
-  border-radius: var(--radius);
+.button-ghost:hover,
+.button-ghost:focus {
+  background: rgba(58, 110, 217, 0.08);
+}
+
+main {
+  padding: 0 1.5rem 4rem;
+}
+
+.page {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.layout-home,
+.layout-pricing,
+.layout-provider {
+  margin-top: 3rem;
+}
+
+.content-area {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: sticky;
+  top: 2rem;
+}
+
+.sidebar-card {
+  background: #ffffff;
+  border-radius: var(--radius-lg);
   padding: 1.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  color: rgba(255, 255, 255, 0.95);
-  box-shadow: var(--shadow);
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  box-shadow: 0 18px 35px rgba(58, 110, 217, 0.08);
+  display: grid;
+  gap: 0.9rem;
 }
 
-.hero-card h2 {
-  margin-top: 0;
-  font-size: 1.4rem;
+.sidebar-card h2 {
+  margin: 0;
+  font-size: 1.3rem;
 }
 
-.hero-card ul {
+.sidebar-list {
   list-style: none;
-  margin: 1rem 0 0;
   padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.sidebar-list a {
+  color: var(--color-blue);
+}
+
+.layout-home .sidebar-card:first-child {
+  background: linear-gradient(135deg, var(--color-blue-soft), #ffffff);
+}
+
+.sidebar-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: grid;
   gap: 0.75rem;
 }
 
-.hero-card li {
+.sidebar-steps li {
   display: flex;
+  gap: 0.65rem;
   align-items: center;
-  gap: 0.6rem;
+  color: rgba(31, 36, 50, 0.78);
+  font-weight: 500;
 }
 
-.hero-card svg {
-  flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-}
-
-main > section {
-  padding: 4rem 1.5rem;
-}
-
-.section-heading {
-  margin: 0 auto 3rem;
-  text-align: center;
-  max-width: 720px;
-}
-
-.section-heading h2 {
-  font-size: 2rem;
-  margin-bottom: 1rem;
-}
-
-.card-grid {
+.sidebar-step-index {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(58, 110, 217, 0.12);
+  color: var(--color-blue);
   display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.section {
+  margin-bottom: 3.5rem;
+  background: #ffffff;
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  border: 1px solid rgba(58, 110, 217, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.section h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.9rem;
+}
+
+.section-subheading {
+  margin: 2.5rem 0 1rem;
+  font-size: 1.28rem;
+  color: var(--color-blue);
+}
+
+.section p.lead {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  margin-bottom: 2rem;
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.5rem;
 }
 
-@media (min-width: 768px) {
-  .card-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .card-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-.card {
-  background: var(--color-surface);
+.feature-card {
+  background: linear-gradient(135deg, var(--color-blue-soft), rgba(255, 122, 162, 0.12));
+  padding: 1.75rem;
   border-radius: var(--radius);
-  padding: 2rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(12, 35, 64, 0.08);
+  border: 1px solid rgba(58, 110, 217, 0.12);
 }
 
-.card h3 {
+.feature-card h3 {
   margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
 }
 
-.card p {
-  color: var(--color-muted);
-}
 
-.comparison {
-  background: #fff;
-}
-
-.table-wrapper {
+.comparison-table {
   overflow-x: auto;
   border-radius: var(--radius);
-  border: 1px solid rgba(12, 35, 64, 0.12);
-  box-shadow: var(--shadow);
-  background: #fff;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  background: #ffffff;
 }
 
-table {
+.comparison-table table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 720px;
+  min-width: 700px;
 }
 
-thead {
-  background: var(--color-primary);
-  color: #fff;
-}
-
-thead th {
+.comparison-table th,
+.comparison-table td {
+  padding: 1.1rem;
   text-align: left;
-  padding: 1.2rem 1rem;
-  font-size: 0.95rem;
-}
-
-tbody tr:nth-child(even) {
-  background: rgba(10, 74, 124, 0.04);
-}
-
-td,
-th {
-  padding: 1rem;
-  border-bottom: 1px solid rgba(12, 35, 64, 0.12);
+  border-bottom: 1px solid rgba(58, 110, 217, 0.12);
   vertical-align: top;
 }
 
-td strong {
+.comparison-table tbody tr:last-child th,
+.comparison-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.comparison-table th {
+  background: var(--color-blue-soft);
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  color: #1f2432;
+}
+
+.comparison-table td strong {
   display: block;
   margin-bottom: 0.35rem;
 }
@@ -302,126 +694,519 @@ td strong {
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
   font-size: 0.75rem;
-  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 122, 162, 0.18);
+  color: var(--color-primary-dark);
 }
 
-.badge-positive {
-  background: rgba(13, 110, 253, 0.15);
-  color: #0d6efd;
+.cta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--color-blue);
 }
 
-.badge-neutral {
-  background: rgba(47, 60, 72, 0.15);
-  color: var(--color-secondary);
+.table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
 }
 
-.badge-warning {
-  background: rgba(251, 191, 36, 0.2);
-  color: #b45309;
+.provider-cta {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 1rem;
 }
 
-.faq {
-  background: var(--color-background);
+.provider-cta p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(31, 36, 50, 0.65);
+}
+
+.provider-insights {
+  background: transparent;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  margin-bottom: 3rem;
+}
+
+.provider-insights h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.insight-card {
+  background: #ffffff;
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  box-shadow: 0 18px 28px rgba(31, 36, 50, 0.05);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.insight-card h3 {
+  margin: 0;
+}
+
+.insight-card p {
+  margin: 0;
+  color: rgba(31, 36, 50, 0.72);
+}
+
+.insight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #1f2432;
+}
+
+.insight-list span {
+  color: rgba(31, 36, 50, 0.6);
+  font-weight: 500;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.stat {
+  background: linear-gradient(135deg, var(--color-blue-soft), rgba(255, 122, 162, 0.18));
+  color: #1f2432;
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  text-align: center;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+}
+
+.stat strong {
+  display: block;
+  font-size: 2rem;
+  margin-bottom: 0.35rem;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.timeline-step {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: var(--color-blue);
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.05rem;
+  box-shadow: 0 12px 28px rgba(58, 110, 217, 0.22);
+}
+
+.timeline li strong {
+  display: block;
+  font-size: 1.12rem;
+  margin-bottom: 0.35rem;
+}
+
+.timeline li p {
+  margin: 0;
+  color: rgba(31, 36, 50, 0.75);
+}
+
+.timeline-compact {
+  gap: 1.1rem;
+}
+
+.timeline-compact .timeline-step {
+  width: 36px;
+  height: 36px;
+  font-size: 0.95rem;
+  background: var(--color-primary);
+  box-shadow: 0 10px 22px rgba(255, 122, 162, 0.25);
+}
+
+.timeline-compact li strong {
+  font-size: 1.05rem;
+}
+
+.timeline-compact li p {
+  font-size: 0.95rem;
 }
 
 .faq-list {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .faq-item {
-  background: var(--color-surface);
+  background: linear-gradient(135deg, var(--color-blue-soft), rgba(255, 122, 162, 0.12));
   border-radius: var(--radius);
-  padding: 1.75rem;
-  border: 1px solid rgba(12, 35, 64, 0.08);
-  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
 }
 
 .faq-item h3 {
   margin-top: 0;
-  font-size: 1.15rem;
+  margin-bottom: 0.6rem;
+  font-size: 1.1rem;
 }
 
-.cta {
-  background: linear-gradient(135deg, rgba(10, 74, 124, 0.95), rgba(15, 23, 42, 0.95));
-  color: #fff;
-  text-align: center;
-  padding: 4.5rem 1.5rem;
+.cta-banner {
+  background: linear-gradient(135deg, var(--color-rose-soft), var(--color-blue-soft));
+  color: #1f2432;
+  border-radius: var(--radius-lg);
+  padding: 2.75rem 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+  border: 1px solid rgba(58, 110, 217, 0.08);
+  box-shadow: var(--shadow-soft);
 }
 
-.cta .button-primary {
-  background: #0d6efd;
-  color: #fff;
-  box-shadow: 0 20px 35px rgba(13, 110, 253, 0.35);
-}
-
-.cta .button-primary:hover,
-.cta .button-primary:focus {
-  transform: translateY(-3px);
+.cta-banner p {
+  margin: 0;
+  color: rgba(31, 36, 50, 0.75);
 }
 
 footer {
-  background: #0c1b29;
-  color: rgba(255, 255, 255, 0.75);
-  padding: 2.5rem 1.5rem;
+  background: #ffffff;
+  border-top: 1px solid rgba(58, 110, 217, 0.08);
+  color: rgba(31, 36, 50, 0.7);
+  padding: 2rem 1.5rem 3rem;
 }
 
 .footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.footer-inner ul {
+  list-style: none;
+  display: flex;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-inner a {
+  color: rgba(47, 28, 63, 0.8);
+}
+
+.badge-success {
+  background: rgba(88, 209, 196, 0.22);
+  color: #269680;
+}
+
+.badge-neutral {
+  background: rgba(88, 209, 196, 0.12);
+  color: var(--color-primary);
+}
+
+.review-snippet {
+  background: var(--color-rose-soft);
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  margin-top: 2rem;
+}
+
+.review-snippet blockquote {
+  margin: 0;
+  font-style: italic;
+  color: var(--color-muted);
+}
+
+.review-snippet cite {
+  display: block;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.provider-hero {
+  background: linear-gradient(135deg, #ffffff, var(--color-rose-soft));
+  color: #1f2432;
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  display: grid;
+  gap: 1rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.provider-hero p {
+  color: rgba(31, 36, 50, 0.72);
+}
+
+.provider-meta {
+  display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
 }
 
-footer nav ul {
-  gap: 0.75rem;
+.provider-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
 }
 
-.skip-link {
-  position: absolute;
-  top: -100px;
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 0.75rem 1rem;
-  background: #fff;
-  color: var(--color-primary);
-  border-radius: 8px;
-  box-shadow: var(--shadow);
-  transition: top 0.2s ease;
-  z-index: 1000;
+.highlight-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: grid;
+  gap: 1rem;
 }
 
-.skip-link:focus {
-  top: 16px;
+.highlight-item {
+  background: linear-gradient(135deg, var(--color-blue-soft), rgba(255, 122, 162, 0.12));
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
 }
 
-@media (max-width: 720px) {
-  nav {
-    flex-direction: column;
+.highlight-item h3 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.15rem;
+}
+
+.budget-callout {
+  background: linear-gradient(135deg, var(--color-mint), #ffffff 55%, var(--color-peach-soft));
+  border-radius: var(--radius-lg);
+  padding: 2rem 2.2rem;
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  box-shadow: 0 20px 36px rgba(58, 110, 217, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.budget-callout h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.budget-callout p {
+  margin: 0;
+  color: rgba(31, 36, 50, 0.72);
+}
+
+.budget-callout ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.budget-callout li {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  font-weight: 500;
+}
+
+.budget-callout li::before {
+  content: "→";
+  color: var(--color-blue);
+  font-weight: 700;
+  margin-top: 0.1rem;
+}
+
+.plan-table {
+  border: 1px solid rgba(58, 110, 217, 0.12);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.plan-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.plan-table th,
+.plan-table td {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.plan-table th {
+  background: var(--color-blue-soft);
+  font-size: 0.95rem;
+}
+
+.plan-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: rgba(31, 36, 50, 0.6);
+  font-size: 0.95rem;
+}
+
+.breadcrumb a {
+  color: rgba(31, 36, 50, 0.75);
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    margin-top: 2.5rem;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+}
+
+@media (max-width: 960px) {
+  header {
+    padding: 1.5rem 1.25rem 2.5rem;
+  }
+
+  .header-top {
     align-items: flex-start;
   }
 
-  nav ul {
-    flex-wrap: wrap;
+  .nav-toggle {
+    display: inline-flex;
   }
 
-  .hero {
-    text-align: center;
+  .site-nav {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    right: 0;
+    background: #ffffff;
+    border: 1px solid rgba(58, 110, 217, 0.16);
+    border-radius: var(--radius);
+    padding: 1rem;
+    width: min(320px, 90vw);
+    box-shadow: 0 20px 35px rgba(31, 36, 50, 0.12);
+    display: none;
   }
 
-  .hero-cta {
+  .site-nav.is-open {
+    display: block;
+  }
+
+  .site-nav ul {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .menu-item.has-submenu {
+    width: 100%;
+  }
+
+  .submenu {
+    position: static;
+    width: 100%;
+    margin-top: 0.5rem;
+    box-shadow: none;
+    border: 1px solid rgba(58, 110, 217, 0.12);
+    border-radius: var(--radius);
+  }
+
+  .submenu li a {
+    padding: 0.55rem 0.9rem;
+  }
+
+  .section {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .section {
+    padding: 1.75rem;
+  }
+
+  .intro-section {
+    padding: 2.1rem 1.9rem;
+  }
+
+  .intro-meta {
+    gap: 0.6rem;
+  }
+
+  .intro-meta-item {
+    width: 100%;
     justify-content: center;
   }
 
-  .hero-card {
-    text-align: left;
+  .intro-highlights {
+    grid-template-columns: 1fr;
+  }
+
+  .cta-group {
+    flex-direction: column;
+  }
+
+  .usecase-card {
+    padding: 1.8rem;
+  }
+
+  .timeline li {
+    gap: 0.75rem;
+  }
+
+  .timeline-step {
+    width: 34px;
+    height: 34px;
+    font-size: 0.9rem;
+  }
+
+  .comparison-table table {
+    min-width: 600px;
+  }
+
+  .budget-callout {
+    padding: 1.75rem;
   }
 
   .footer-inner {


### PR DESCRIPTION
## Summary
- allégé le hero de la home, ajouté les cas clients et détaillé la méthodologie via une frise en quatre étapes
- enrichi la page « les moins chers » avec checklist budget, plan de négociation et nouvelles cartes de sidebar
- ajouté pour chaque fiche cabinet un plan d’action chronologique et une checklist d’onboarding, avec les styles associés

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dcf3c95ebc8331b93411291049cab0