### PR TITLE
Revamp homepage hero and improve navigation submenu

### DIFF
--- a/cabinets/clementine.html
+++ b/cabinets/clementine.html
@@ -34,6 +34,20 @@
             <ul>
               <li><a href="../index.html#comparatif">Comparatif</a></li>
               <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="indy.html">Indy</a></li>
+                  <li><a href="dougs.html">Dougs</a></li>
+                  <li><a href="keobiz.html">Keobiz</a></li>
+                  <li><a href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="livli.html">Livli</a></li>
+                  <li><a href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="../index.html#faq">FAQ</a></li>
               <li><a href="../index.html#contact">Contact</a></li>
             </ul>
@@ -230,6 +244,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/cabinets/dougs.html
+++ b/cabinets/dougs.html
@@ -34,6 +34,20 @@
             <ul>
               <li><a href="../index.html#comparatif">Comparatif</a></li>
               <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="indy.html">Indy</a></li>
+                  <li><a href="dougs.html">Dougs</a></li>
+                  <li><a href="keobiz.html">Keobiz</a></li>
+                  <li><a href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="livli.html">Livli</a></li>
+                  <li><a href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="../index.html#faq">FAQ</a></li>
               <li><a href="../index.html#contact">Contact</a></li>
             </ul>
@@ -229,6 +243,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/cabinets/indy.html
+++ b/cabinets/indy.html
@@ -34,6 +34,20 @@
             <ul>
               <li><a href="../index.html#comparatif">Comparatif</a></li>
               <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="indy.html">Indy</a></li>
+                  <li><a href="dougs.html">Dougs</a></li>
+                  <li><a href="keobiz.html">Keobiz</a></li>
+                  <li><a href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="livli.html">Livli</a></li>
+                  <li><a href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="../index.html#faq">FAQ</a></li>
               <li><a href="../index.html#contact">Contact</a></li>
             </ul>
@@ -231,6 +245,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/cabinets/keobiz.html
+++ b/cabinets/keobiz.html
@@ -34,6 +34,20 @@
             <ul>
               <li><a href="../index.html#comparatif">Comparatif</a></li>
               <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="indy.html">Indy</a></li>
+                  <li><a href="dougs.html">Dougs</a></li>
+                  <li><a href="keobiz.html">Keobiz</a></li>
+                  <li><a href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="livli.html">Livli</a></li>
+                  <li><a href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="../index.html#faq">FAQ</a></li>
               <li><a href="../index.html#contact">Contact</a></li>
             </ul>
@@ -230,6 +244,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/cabinets/lexpert.html
+++ b/cabinets/lexpert.html
@@ -34,6 +34,20 @@
             <ul>
               <li><a href="../index.html#comparatif">Comparatif</a></li>
               <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="indy.html">Indy</a></li>
+                  <li><a href="dougs.html">Dougs</a></li>
+                  <li><a href="keobiz.html">Keobiz</a></li>
+                  <li><a href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="livli.html">Livli</a></li>
+                  <li><a href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="../index.html#faq">FAQ</a></li>
               <li><a href="../index.html#contact">Contact</a></li>
             </ul>
@@ -228,6 +242,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/cabinets/livli.html
+++ b/cabinets/livli.html
@@ -34,6 +34,20 @@
             <ul>
               <li><a href="../index.html#comparatif">Comparatif</a></li>
               <li><a href="../index.html#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="indy.html">Indy</a></li>
+                  <li><a href="dougs.html">Dougs</a></li>
+                  <li><a href="keobiz.html">Keobiz</a></li>
+                  <li><a href="lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="livli.html">Livli</a></li>
+                  <li><a href="clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="../index.html#faq">FAQ</a></li>
               <li><a href="../index.html#contact">Contact</a></li>
             </ul>
@@ -229,6 +243,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <link rel="preload" href="styles.css" as="style" />
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body>
+  <body class="homepage">
     <a href="#contenu" class="skip-link">Aller au contenu</a>
     <header>
       <div class="header-inner">
@@ -46,122 +46,199 @@
             <ul>
               <li><a href="#comparatif">Comparatif</a></li>
               <li><a href="#methodologie">Méthodologie</a></li>
+              <li class="has-submenu">
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-haspopup="true">
+                  Fiches cabinets
+                  <span class="chevron" aria-hidden="true"></span>
+                </button>
+                <ul class="submenu" hidden>
+                  <li><a href="cabinets/indy.html">Indy</a></li>
+                  <li><a href="cabinets/dougs.html">Dougs</a></li>
+                  <li><a href="cabinets/keobiz.html">Keobiz</a></li>
+                  <li><a href="cabinets/lexpert.html">L-expert-comptable.com</a></li>
+                  <li><a href="cabinets/livli.html">Livli</a></li>
+                  <li><a href="cabinets/clementine.html">Clémentine</a></li>
+                </ul>
+              </li>
               <li><a href="#faq">FAQ</a></li>
               <li><a href="#contact">Contact</a></li>
             </ul>
           </nav>
         </div>
         <div class="hero hero-home" id="contenu">
-          <h1>Comparez les cabinets comptables en un clin d'œil</h1>
-          <p>
-            Une introduction claire, un tableau synthétique et des fiches détaillées pour choisir l'expert-comptable en ligne
-            qui vous ressemble.
+          <span class="hero-badge">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <path
+                d="M12 3l2 3.9 4.4.64-3.2 3.12.76 4.35L12 13.77 7.99 15.01l.76-4.35-3.2-3.12L10 6.9 12 3z"
+                fill="currentColor"
+              />
+            </svg>
+            Édition indépendante 2024
+          </span>
+          <h1>Le comparatif de cabinets comptables en ligne à garder sous la main</h1>
+          <p class="hero-lead">
+            Notre équipe teste les solutions, vérifie les avis et négocie les offres pour vous proposer un panorama clair et
+            humain. Le tableau comparatif reste la porte d'entrée principale pour choisir sereinement votre expert-comptable.
           </p>
-          <div class="hero-cta">
-            <a class="button button-primary" href="#comparatif">Voir le comparatif 2024</a>
+          <div class="hero-focus-card">
+            <div class="hero-focus-icon" aria-hidden="true">
+              <svg viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
+                <rect x="3" y="6" width="22" height="16" rx="3" fill="currentColor" opacity="0.14" />
+                <path
+                  d="M8 11h12M8 14h12M8 17h7"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+            <div class="hero-focus-content">
+              <p>
+                <strong>Le tableau comparatif</strong> met face à face tarifs, positionnement et accompagnement sur 24 critères
+                objectivés.
+              </p>
+              <a class="button button-primary" href="#comparatif">Consulter le tableau comparatif</a>
+            </div>
           </div>
-          <p class="hero-note">Scores mis à jour, avis clients vérifiés et offres négociées pour freelances, TPE et e-commerçants.</p>
+          <ul class="hero-checklist" role="list">
+            <li>
+              <span class="hero-check-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2.5 8.5l3 3 8-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                </svg>
+              </span>
+              Scores mis à jour chaque trimestre à partir des retours dirigeants et des roadmaps produits.
+            </li>
+            <li>
+              <span class="hero-check-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2.5 8.5l3 3 8-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                </svg>
+              </span>
+              Fiches cabinets enrichies : cas d'usage, limites et conseils pour onboarder rapidement.
+            </li>
+            <li>
+              <span class="hero-check-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2.5 8.5l3 3 8-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                </svg>
+              </span>
+              Accompagnement neutre pour comparer les devis et préparer votre migration comptable.
+            </li>
+          </ul>
+          <div class="hero-trust">
+            <div class="hero-trust-figure">
+              <strong>312</strong>
+              <span>dirigeants accompagnés en 2023</span>
+            </div>
+            <p>Notes vérifiées, offres négociées et plan d'intégration personnalisé offert.</p>
+          </div>
+          <div class="hero-cta">
+            <a class="button button-secondary" href="#methodologie">Comprendre notre méthodologie</a>
+            <a class="button button-ghost" href="#contact">Parler à un expert</a>
+          </div>
         </div>
       </div>
     </header>
 
     <main>
       <div class="page">
-        <section class="section" id="comparatif" aria-labelledby="titre-comparatif">
-              <h2 id="titre-comparatif">Tableau comparatif 2024 des cabinets comptables en ligne</h2>
-              <p class="lead">
-                Comparez en un coup d'œil le positionnement, les points forts et les forfaits des acteurs sélectionnés. Chaque
-                ligne donne accès à une fiche détaillée avec recommandations, avis clients et plan d'action.
-              </p>
-              <div class="comparison-table" role="region" aria-labelledby="titre-comparatif">
-                <table>
-                  <caption class="sr-only">Comparaison des cabinets comptables en ligne</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">Cabinet</th>
-                      <th scope="col">Positionnement</th>
-                      <th scope="col">Atouts majeurs</th>
-                      <th scope="col">Tarifs indicatifs</th>
-                      <th scope="col">Action</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th scope="row">Indy</th>
-                      <td>Solution automatisée pour indépendants et professions libérales.</td>
-                      <td>
-                        <strong>Automatisation native</strong>
-                        <span class="badge">IA & Pilotage</span>
-                        Déclarations fiscales et TVA en quelques clics.
-                      </td>
-                      <td>Formule à partir de 49&nbsp;€&nbsp;HT/mois.</td>
-                      <td><a class="cta-link" href="cabinets/indy.html">Voir l'analyse</a></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Dougs</th>
-                      <td>Cabinet 100&nbsp;% en ligne axé sur la pédagogie et la mobilité.</td>
-                      <td>
-                        <strong>Application complète</strong>
-                        <span class="badge badge-success">Temps réel</span>
-                        Tableaux de bord, alertes proactives et webinars mensuels.
-                      </td>
-                      <td>Essentiels à 79&nbsp;€&nbsp;HT/mois.</td>
-                      <td><a class="cta-link" href="cabinets/dougs.html">Voir l'analyse</a></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Keobiz</th>
-                      <td>Accompagnement global pour créateurs et sociétés en croissance.</td>
-                      <td>
-                        <strong>Offre juridique intégrée</strong>
-                        <span class="badge badge-neutral">360°</span>
-                        Formalités et missions juridiques incluses.
-                      </td>
-                      <td>Abonnement dès 49&nbsp;€&nbsp;HT/mois.</td>
-                      <td><a class="cta-link" href="cabinets/keobiz.html">Voir l'analyse</a></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">L-expert-comptable.com</th>
-                      <td>Cabinet digital historique avec forte expertise juridique.</td>
-                      <td>
-                        <strong>Ressources pédagogiques</strong>
-                        <span class="badge">Communauté</span>
-                        Webinaires, guides pratiques et club dirigeant.
-                      </td>
-                      <td>Forfaits sur-mesure à partir de 69&nbsp;€&nbsp;HT/mois.</td>
-                      <td><a class="cta-link" href="cabinets/lexpert.html">Voir l'analyse</a></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Livli</th>
-                      <td>Spécialiste e-commerce et activités digitales.</td>
-                      <td>
-                        <strong>Intégrations API</strong>
-                        <span class="badge badge-success">E-commerce</span>
-                        Connexions Shopify, Amazon et marketplace.
-                      </td>
-                      <td>Formule Comfort à 79&nbsp;€&nbsp;HT/mois.</td>
-                      <td><a class="cta-link" href="cabinets/livli.html">Voir l'analyse</a></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Clémentine</th>
-                      <td>Pilotage financier premium pour TPE/PME en croissance.</td>
-                      <td>
-                        <strong>Reporting actionnable</strong>
-                        <span class="badge badge-neutral">Conseil</span>
-                        Contrôleur de gestion et réunions trimestrielles.
-                      </td>
-                      <td>Pack croissance sur devis personnalisé.</td>
-                      <td><a class="cta-link" href="cabinets/clementine.html">Voir l'analyse</a></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <div class="review-snippet">
-                <blockquote>
-                  «&nbsp;Grâce au comparatif Comptable Pro, nous avons identifié le cabinet capable d'automatiser nos flux
-                  Shopify et d'anticiper nos besoins de trésorerie. L'onboarding a été bouclé en deux semaines.&nbsp;»
-                </blockquote>
-                <cite>— Sarah M., fondatrice d'une DNVB</cite>
-              </div>
+        <section class="section section--accent" id="comparatif" aria-labelledby="titre-comparatif">
+          <h2 id="titre-comparatif">Tableau comparatif 2024 des cabinets comptables en ligne</h2>
+          <p class="lead">
+            Comparez en un coup d'œil le positionnement, les points forts et les forfaits des acteurs sélectionnés. Chaque ligne
+            donne accès à une fiche détaillée avec recommandations, avis clients et plan d'action.
+          </p>
+          <div class="comparison-table" role="region" aria-labelledby="titre-comparatif">
+            <table>
+              <caption class="sr-only">Comparaison des cabinets comptables en ligne</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Cabinet</th>
+                  <th scope="col">Positionnement</th>
+                  <th scope="col">Atouts majeurs</th>
+                  <th scope="col">Tarifs indicatifs</th>
+                  <th scope="col">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">Indy</th>
+                  <td>Solution automatisée pour indépendants et professions libérales.</td>
+                  <td>
+                    <strong>Automatisation native</strong>
+                    <span class="badge">IA & Pilotage</span>
+                    Déclarations fiscales et TVA en quelques clics.
+                  </td>
+                  <td>Formule à partir de 49&nbsp;€&nbsp;HT/mois.</td>
+                  <td><a class="cta-link" href="cabinets/indy.html">Voir l'analyse</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">Dougs</th>
+                  <td>Cabinet 100&nbsp;% en ligne axé sur la pédagogie et la mobilité.</td>
+                  <td>
+                    <strong>Application complète</strong>
+                    <span class="badge badge-success">Temps réel</span>
+                    Tableaux de bord, alertes proactives et webinars mensuels.
+                  </td>
+                  <td>Essentiels à 79&nbsp;€&nbsp;HT/mois.</td>
+                  <td><a class="cta-link" href="cabinets/dougs.html">Voir l'analyse</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">Keobiz</th>
+                  <td>Accompagnement global pour créateurs et sociétés en croissance.</td>
+                  <td>
+                    <strong>Offre juridique intégrée</strong>
+                    <span class="badge badge-neutral">360°</span>
+                    Formalités et missions juridiques incluses.
+                  </td>
+                  <td>Abonnement dès 49&nbsp;€&nbsp;HT/mois.</td>
+                  <td><a class="cta-link" href="cabinets/keobiz.html">Voir l'analyse</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">L-expert-comptable.com</th>
+                  <td>Cabinet digital historique avec forte expertise juridique.</td>
+                  <td>
+                    <strong>Ressources pédagogiques</strong>
+                    <span class="badge">Communauté</span>
+                    Webinaires, guides pratiques et club dirigeant.
+                  </td>
+                  <td>Forfaits sur-mesure à partir de 69&nbsp;€&nbsp;HT/mois.</td>
+                  <td><a class="cta-link" href="cabinets/lexpert.html">Voir l'analyse</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">Livli</th>
+                  <td>Spécialiste e-commerce et activités digitales.</td>
+                  <td>
+                    <strong>Intégrations API</strong>
+                    <span class="badge badge-success">E-commerce</span>
+                    Connexions Shopify, Amazon et marketplace.
+                  </td>
+                  <td>Formule Comfort à 79&nbsp;€&nbsp;HT/mois.</td>
+                  <td><a class="cta-link" href="cabinets/livli.html">Voir l'analyse</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">Clémentine</th>
+                  <td>Pilotage financier premium pour TPE/PME en croissance.</td>
+                  <td>
+                    <strong>Reporting actionnable</strong>
+                    <span class="badge badge-neutral">Conseil</span>
+                    Contrôleur de gestion et réunions trimestrielles.
+                  </td>
+                  <td>Pack croissance sur devis personnalisé.</td>
+                  <td><a class="cta-link" href="cabinets/clementine.html">Voir l'analyse</a></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="review-snippet">
+            <blockquote>
+              «&nbsp;Grâce au comparatif Comptable Pro, nous avons identifié le cabinet capable d'automatiser nos flux Shopify et
+              d'anticiper nos besoins de trésorerie. L'onboarding a été bouclé en deux semaines.&nbsp;»
+            </blockquote>
+            <cite>— Sarah M., fondatrice d'une DNVB</cite>
+          </div>
         </section>
 
         <section class="section" id="methodologie" aria-labelledby="titre-methodologie">
@@ -209,7 +286,7 @@
           </div>
         </section>
 
-        <section class="section" id="faq" aria-labelledby="titre-faq">
+        <section class="section section--soft" id="faq" aria-labelledby="titre-faq">
               <h2 id="titre-faq">Questions fréquentes</h2>
               <div class="faq-list">
                 <article class="faq-item">
@@ -261,6 +338,78 @@
       const annee = document.getElementById("annee");
       if (annee) {
         annee.textContent = new Date().getFullYear();
+      }
+
+      const submenuWrappers = Array.from(document.querySelectorAll(".has-submenu"));
+      if (submenuWrappers.length) {
+        const closeWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = true;
+          toggle.setAttribute("aria-expanded", "false");
+          wrapper.classList.remove("is-open");
+        };
+
+        const openWrapper = (wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+          submenu.hidden = false;
+          toggle.setAttribute("aria-expanded", "true");
+          wrapper.classList.add("is-open");
+        };
+
+        const closeAll = () => {
+          submenuWrappers.forEach((wrapper) => closeWrapper(wrapper));
+        };
+
+        submenuWrappers.forEach((wrapper) => {
+          const toggle = wrapper.querySelector(".submenu-toggle");
+          const submenu = wrapper.querySelector(".submenu");
+          if (!toggle || !submenu) return;
+
+          toggle.setAttribute("aria-haspopup", "true");
+
+          toggle.addEventListener("click", (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            closeAll();
+            if (!expanded) {
+              openWrapper(wrapper);
+            }
+          });
+
+          wrapper.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+              closeWrapper(wrapper);
+              toggle.focus();
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              if (toggle.getAttribute("aria-expanded") !== "true") {
+                openWrapper(wrapper);
+              }
+              const firstLink = submenu.querySelector("a");
+              if (firstLink) {
+                firstLink.focus();
+              }
+            }
+          });
+
+          wrapper.addEventListener("focusout", (event) => {
+            if (!wrapper.contains(event.relatedTarget)) {
+              closeWrapper(wrapper);
+            }
+          });
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!submenuWrappers.some((wrapper) => wrapper.contains(event.target))) {
+            closeAll();
+          }
+        });
       }
     </script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -120,73 +120,260 @@ nav a:focus {
   background: rgba(255, 122, 162, 0.15);
 }
 
-.hero {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 2.5rem;
+.has-submenu {
+  position: relative;
+}
+
+.submenu-toggle {
+  display: inline-flex;
   align-items: center;
+  gap: 0.4rem;
+  font: inherit;
+  font-weight: 600;
+  color: rgba(47, 28, 63, 0.8);
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.submenu-toggle:hover,
+.submenu-toggle:focus {
+  color: #2f1c3f;
+  background: rgba(255, 122, 162, 0.15);
+}
+
+.chevron {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  margin-top: 0.1rem;
+}
+
+.has-submenu.is-open .chevron {
+  transform: rotate(-135deg);
+}
+
+.submenu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  min-width: 210px;
+  padding: 0.75rem;
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 18px 36px rgba(47, 28, 63, 0.18);
+  border: 1px solid rgba(255, 122, 162, 0.22);
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+  z-index: 20;
+}
+
+.submenu li a {
+  display: block;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius);
+  font-weight: 600;
+  color: rgba(47, 28, 63, 0.8);
+}
+
+.submenu li a:hover,
+.submenu li a:focus {
+  background: rgba(255, 122, 162, 0.1);
+  color: #2f1c3f;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  align-items: flex-start;
   margin-top: 3rem;
 }
 
-.hero-home {
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: var(--radius-lg);
-  padding: 2.5rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.hero-home p {
-  max-width: 46ch;
-}
-
-.hero-note {
-  font-size: 0.95rem;
-  color: rgba(47, 28, 63, 0.6);
-  margin: 0;
-  margin-top: 0.5rem;
-}
-
 .hero h1 {
-  margin: 0 0 1.25rem;
-  font-size: clamp(2.4rem, 4vw + 1rem, 3.6rem);
-  line-height: 1.1;
+  margin: 0;
+  font-size: clamp(2.5rem, 4vw + 1rem, 3.65rem);
+  line-height: 1.08;
 }
 
 .hero p {
-  margin-bottom: 1.5rem;
-  color: rgba(47, 28, 63, 0.75);
+  margin: 0;
+  color: rgba(47, 28, 63, 0.76);
+  font-size: 1.1rem;
+}
+
+.hero-home {
+  position: relative;
+  width: 100%;
+  background: linear-gradient(180deg, rgba(255, 249, 252, 0.95), rgba(232, 248, 245, 0.65));
+  border-radius: var(--radius-lg);
+  padding: 3.25rem;
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.hero-home::before,
+.hero-home::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(0.5px);
+  opacity: 0.65;
+  z-index: 0;
+}
+
+.hero-home::before {
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(255, 122, 162, 0.32) 0%, rgba(255, 122, 162, 0) 70%);
+  top: -80px;
+  right: -60px;
+}
+
+.hero-home::after {
+  width: 260px;
+  height: 260px;
+  background: radial-gradient(circle, rgba(88, 209, 196, 0.28) 0%, rgba(88, 209, 196, 0) 70%);
+  bottom: -90px;
+  left: -70px;
+}
+
+.hero-home > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--color-primary-dark);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  box-shadow: 0 12px 28px rgba(255, 122, 162, 0.22);
+}
+
+.hero-badge svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.hero-lead {
+  max-width: 54ch;
   font-size: 1.15rem;
+}
+
+.hero-focus-card {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 1.6rem 1.8rem;
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 122, 162, 0.24);
+  box-shadow: 0 18px 40px rgba(255, 122, 162, 0.12);
+}
+
+.hero-focus-icon {
+  display: grid;
+  place-items: center;
+  width: 62px;
+  height: 62px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.16), rgba(88, 209, 196, 0.16));
+  color: var(--color-primary-dark);
+}
+
+.hero-focus-icon svg {
+  width: 34px;
+  height: 34px;
+}
+
+.hero-focus-content p {
+  font-size: 1.05rem;
+  color: rgba(47, 28, 63, 0.82);
+  margin-bottom: 1rem;
+}
+
+.hero-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.hero-checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 122, 162, 0.16);
+  font-size: 0.98rem;
+  color: rgba(47, 28, 63, 0.78);
+}
+
+.hero-check-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: rgba(88, 209, 196, 0.25);
+  color: var(--color-secondary);
+}
+
+.hero-check-icon svg {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.hero-trust {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: var(--radius);
+  padding: 1.2rem 1.4rem;
+  border: 1px solid rgba(88, 209, 196, 0.18);
+  box-shadow: 0 16px 32px rgba(88, 209, 196, 0.18);
+}
+
+.hero-trust-figure {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(47, 28, 63, 0.66);
+}
+
+.hero-trust-figure strong {
+  font-size: 2.4rem;
+  line-height: 1;
+  color: var(--color-primary-dark);
 }
 
 .hero-cta {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-}
-
-.hero-highlights {
-  display: grid;
-  gap: 1rem;
-  margin-top: 2rem;
-}
-
-.hero-highlights li {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  list-style: none;
-  padding: 0.9rem 1.1rem;
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: var(--radius);
-  border: 1px solid rgba(255, 122, 162, 0.25);
-  color: #2f1c3f;
-}
-
-.hero-highlights svg {
-  width: 22px;
-  height: 22px;
-  flex: 0 0 auto;
-  color: var(--color-secondary);
 }
 
 .button {
@@ -216,6 +403,20 @@ nav a:focus {
   border: 2px solid rgba(255, 122, 162, 0.25);
 }
 
+.button-ghost {
+  background: transparent;
+  color: rgba(47, 28, 63, 0.78);
+  border: 2px solid rgba(47, 28, 63, 0.12);
+}
+
+.button-secondary:hover,
+.button-secondary:focus,
+.button-ghost:hover,
+.button-ghost:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(47, 28, 63, 0.12);
+}
+
 main {
   padding: 0 1.5rem 4rem;
 }
@@ -240,6 +441,43 @@ main {
   box-shadow: var(--shadow-soft);
 }
 
+.homepage .section {
+  position: relative;
+  overflow: hidden;
+}
+
+.homepage .section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.1), rgba(88, 209, 196, 0.08));
+  opacity: 0.6;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.homepage .section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.homepage .section.section--accent::before {
+  opacity: 0.85;
+}
+
+.homepage .section.section--accent {
+  border: 1px solid rgba(255, 122, 162, 0.2);
+}
+
+.homepage .section.section--soft::before {
+  opacity: 0.4;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(88, 209, 196, 0.12));
+}
+
+.homepage .cta-banner::before {
+  display: none;
+}
+
 .section h2 {
   margin-top: 0;
   margin-bottom: 1rem;
@@ -258,11 +496,47 @@ main {
   gap: 1.5rem;
 }
 
+.homepage .features-grid {
+  grid-template-columns: 1fr;
+}
+
 .feature-card {
-  background: linear-gradient(135deg, rgba(255, 122, 162, 0.08), rgba(88, 209, 196, 0.08));
-  padding: 1.75rem;
+  position: relative;
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.08), rgba(88, 209, 196, 0.1));
+  padding: 1.75rem 1.75rem 1.75rem 4.25rem;
   border-radius: var(--radius);
-  border: 1px solid rgba(255, 122, 162, 0.18);
+  border: 1px solid rgba(255, 122, 162, 0.2);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  overflow: hidden;
+}
+
+.feature-card::before {
+  content: "";
+  position: absolute;
+  top: 1.6rem;
+  left: 1.5rem;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(255, 122, 162, 0.6), rgba(88, 209, 196, 0.5));
+  box-shadow: 0 12px 24px rgba(255, 122, 162, 0.25);
+}
+
+.feature-card::after {
+  content: "";
+  position: absolute;
+  top: 2.2rem;
+  left: 2.15rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 12l4 4L19 6'/%3E%3C/svg%3E")
+    center/contain no-repeat;
+}
+
+.feature-card:hover,
+.feature-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 45px rgba(47, 28, 63, 0.12);
 }
 
 .feature-card h3 {
@@ -376,6 +650,10 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1.5rem;
   margin-top: 2.5rem;
+}
+
+.homepage .stat-grid {
+  grid-template-columns: 1fr;
 }
 
 .stat {
@@ -589,6 +867,15 @@ footer {
   .sidebar-card {
     padding: 2rem;
   }
+
+  .hero-home {
+    padding: 2.75rem 2.25rem;
+  }
+
+  .hero-focus-card {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
 }
 
 @media (max-width: 640px) {
@@ -601,8 +888,50 @@ footer {
     align-items: flex-start;
   }
 
+  .has-submenu {
+    width: 100%;
+  }
+
+  .submenu {
+    position: static;
+    margin-top: 0.75rem;
+    box-shadow: none;
+    width: 100%;
+  }
+
   .hero {
     margin-top: 2.5rem;
+  }
+
+  .hero-home {
+    padding: 2.4rem 1.6rem;
+  }
+
+  .hero-cta {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .hero-cta .button {
+    width: 100%;
+  }
+
+  .feature-card {
+    padding: 1.5rem 1.5rem 1.5rem 3.25rem;
+  }
+
+  .feature-card::before {
+    top: 1.45rem;
+    left: 1.15rem;
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+
+  .feature-card::after {
+    top: 1.9rem;
+    left: 1.65rem;
+    width: 1.2rem;
+    height: 1.2rem;
   }
 
   .section {


### PR DESCRIPTION
## Summary
- redesign the homepage hero into a single-column, comparison-focused presentation with refreshed messaging and CTAs
- warm up homepage sections and feature cards with accent backgrounds and interactive styling while keeping the layout single column
- harden the "Fiches cabinets" submenu behaviour and markup across all pages for reliable toggling and keyboard support

## Testing
- Not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd1c0197d88331bbe53cda22ee91fd